### PR TITLE
further tibb tuning

### DIFF
--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -74,7 +74,7 @@ rhs s x =
     _ -> do inCase <- gets psInsideCase
             if inCase
                then unguardedalt s x
-               else prettyNoExt x
+               else unguardedrhs s x
 
 -- | Implement dangling right-hand-sides.
 guardedRhs :: t -> GuardedRhs NodeInfo -> Printer ()
@@ -93,9 +93,18 @@ guardedRhs _ e = prettyNoExt e
 
 -- | Unguarded case alts.
 unguardedalt :: t -> Rhs NodeInfo -> Printer ()
-unguardedalt _ (UnGuardedRhs _ e) = do write " -> "
-                                       indented 4 (pretty e)
+unguardedalt _ (UnGuardedRhs _ e) =
+  do indentSpaces <- getIndentSpaces
+     write " -> "
+     indented indentSpaces (pretty e)
 unguardedalt _ e = prettyNoExt e
+
+unguardedrhs :: s -> Rhs NodeInfo -> Printer ()
+unguardedrhs _ (UnGuardedRhs _ e) =
+  do indentSpaces <- getIndentSpaces
+     write " = "
+     indented indentSpaces (pretty e)
+unguardedrhs _ e = prettyNoExt e
 
 -- | Expression customizations.
 exp :: t -> Exp NodeInfo -> Printer ()

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -208,7 +208,7 @@ decl _ (PatBind _ pat rhs' mbinds) =
            Just binds ->
              do newline
                 indented 2
-                         (do write "where "
+                         (do write "where"
                              newline
                              indented 2 (pretty binds))
 -- | Handle records specially for a prettier display (see guide).

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -58,7 +58,7 @@ johanTibell =
 
 -- | Handle do specially and also space out guards more.
 rhs :: t -> Rhs NodeInfo -> Printer ()
-rhs _ x =
+rhs s x =
   case x of
     UnGuardedRhs _ (Do _ dos) ->
       swing (write " = do")
@@ -71,7 +71,10 @@ rhs _ x =
                                  do write "|"
                                     pretty p)
                               gas))
-    _ -> prettyNoExt x
+    _ -> do inCase <- gets psInsideCase
+            if inCase
+               then unguardedalt s x
+               else prettyNoExt x
 
 -- | Implement dangling right-hand-sides.
 guardedRhs :: t -> GuardedRhs NodeInfo -> Printer ()
@@ -87,6 +90,12 @@ guardedRhs _ (GuardedRhs _ stmts (Do _ dos)) =
      swing (write " = do")
            (lined (map pretty dos))
 guardedRhs _ e = prettyNoExt e
+
+-- | Unguarded case alts.
+unguardedalt :: t -> Rhs NodeInfo -> Printer ()
+unguardedalt _ (UnGuardedRhs _ e) = do write " -> "
+                                       indented 4 (pretty e)
+unguardedalt _ e = prettyNoExt e
 
 -- | Expression customizations.
 exp :: t -> Exp NodeInfo -> Printer ()

--- a/test/johan-tibell/expected/1.exp
+++ b/test/johan-tibell/expected/1.exp
@@ -1,4 +1,3 @@
 getGitProvider :: EventProvider GitRecord ()
-getGitProvider = 
-    EventProvider {getModuleName = "Git"
-                  ,getEvents = getRepoCommits}
+getGitProvider = EventProvider {getModuleName = "Git"
+                               ,getEvents = getRepoCommits}

--- a/test/johan-tibell/expected/1.exp
+++ b/test/johan-tibell/expected/1.exp
@@ -1,3 +1,5 @@
 getGitProvider :: EventProvider GitRecord ()
-getGitProvider = EventProvider {getModuleName = "Git"
-                               ,getEvents = getRepoCommits}
+getGitProvider = EventProvider
+    { getModuleName = "Git"
+    , getEvents = getRepoCommits
+    }

--- a/test/johan-tibell/expected/2.exp
+++ b/test/johan-tibell/expected/2.exp
@@ -1,0 +1,6 @@
+strToMonth :: String -> Int
+strToMonth month = 
+    case month of
+        "Jan" -> 1
+        "Feb" -> 2
+        _ -> error $ "Unknown month " ++ month

--- a/test/johan-tibell/expected/2.exp
+++ b/test/johan-tibell/expected/2.exp
@@ -1,6 +1,5 @@
 strToMonth :: String -> Int
-strToMonth month = 
-    case month of
+strToMonth month = case month of
         "Jan" -> 1
         "Feb" -> 2
         _ -> error $ "Unknown month " ++ month

--- a/test/johan-tibell/expected/3.exp
+++ b/test/johan-tibell/expected/3.exp
@@ -1,0 +1,6 @@
+sayHello :: IO ()
+sayHello = do
+    name <- getLine
+    putStrLn $ greeting name
+  where
+    greeting name = "Hello, " ++ name ++ "!"

--- a/test/johan-tibell/expected/4.exp
+++ b/test/johan-tibell/expected/4.exp
@@ -1,0 +1,8 @@
+commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
+commitToEvent gitFolderPath timezone commit = Event.Event
+    { pluginName = getModuleName getGitProvider
+    , eventIcon = "glyphicon-cog"
+    , eventDate = localTimeToUTC 
+          timezone
+          (commitDate commit)
+    }

--- a/test/johan-tibell/tests/2.test
+++ b/test/johan-tibell/tests/2.test
@@ -1,0 +1,5 @@
+strToMonth :: String -> Int
+strToMonth month = case month of
+    "Jan" -> 1
+    "Feb" -> 2
+    _ -> error $ "Unknown month " ++ month

--- a/test/johan-tibell/tests/3.test
+++ b/test/johan-tibell/tests/3.test
@@ -1,0 +1,6 @@
+sayHello :: IO ()
+sayHello = do
+    name <- getLine
+    putStrLn $ greeting name
+    where
+        greeting name = "Hello, " ++ name ++ "!"

--- a/test/johan-tibell/tests/4.test
+++ b/test/johan-tibell/tests/4.test
@@ -1,0 +1,7 @@
+commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
+commitToEvent gitFolderPath timezone commit = Event.Event
+    {
+        pluginName = getModuleName getGitProvider,
+        eventIcon = "glyphicon-cog",
+        eventDate = localTimeToUTC timezone (commitDate commit)
+    }


### PR DESCRIPTION
* the case statement was putting carriage returns too eagerly after "->"
* less eager carriage return after "=" (which caused trailing spaces)
* get rid of trailing space after "where" (which was always followed by a newline)
* record assignment: indent less (align compared to the left of the expression, not to the data constructor's end)
* moved some functions which were accidentally put at the end of the file in "predicates" and "helpers" sections