### PR TITLE
Add proper delimter for lambda-case

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -690,7 +690,7 @@ exp (LCase _ alts) =
   do write "\\case"
      indentSpaces <- getIndentSpaces
      newline
-     indented indentSpaces (lined (map pretty alts))
+     indented indentSpaces (lined (map (withCaseContext True . pretty) alts))
 exp (MultiIf _ alts) =
   depend (write "if ")
          (lined (map (\p ->


### PR DESCRIPTION
This uses the proper case context for printing lambda case expressions. This fixes issue #57