### PR TITLE
Newlines in do blocks

### DIFF
--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -265,10 +265,14 @@ appExpr app@(App _ f x) = do
 appExpr _ = error "Not an app"
 
 doExpr :: Exp NodeInfo -> Printer ()
-doExpr (Do _ stmts) = do
+doExpr (Do _ stmts@(first:rest)) = do
   write "do"
   newline
-  indented 2 $ lined (map pretty stmts)
+  indented 2 $ do
+    pretty first
+    forM_ (zip stmts rest) $ \(prev, cur) -> do
+      replicateM_ (max 1 $ lineDelta cur prev) newline
+      pretty cur
 doExpr _ = error "Not a do"
 
 listExpr :: Exp NodeInfo -> Printer ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -53,7 +53,7 @@ useTestFiles style test exp = do
 
 mkSpec :: HIndent.Style -> String -> String -> Spec
 mkSpec style input desired = it "works" $
-  case HIndent.reformat style (L.pack input) of
+  case HIndent.reformat style Nothing (L.pack input) of
     Left err      -> expectationFailure ("Error: " ++ err)
     Right builder -> L.unpack (L.toLazyText builder) `shouldBe` desired
 

--- a/test/gibiansky/expected/22.exp
+++ b/test/gibiansky/expected/22.exp
@@ -1,0 +1,4 @@
+a = do
+  a <- b
+
+  print a

--- a/test/gibiansky/tests/22.test
+++ b/test/gibiansky/tests/22.test
@@ -1,0 +1,4 @@
+a = do
+  a <- b
+
+  print a


### PR DESCRIPTION
This PR does two things:

- Fixes the test suite (it was failing to compile)
- Addresses issue #43 