### PR TITLE
Added style tonyDay & hindent-reformat-module to hindent.el

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -26,6 +26,7 @@ library
                      HIndent.Styles.ChrisDone
                      HIndent.Styles.JohanTibell
                      HIndent.Styles.Gibiansky
+                     HIndent.Styles.TonyDay
   build-depends:     base >= 4 && <5
                    , data-default
                    , haskell-src-exts == 1.16.*

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -14,6 +14,7 @@ module HIndent
   ,johanTibell
   ,fundamental
   ,gibiansky
+  ,tonyDay
   -- * Testing
   ,test
   ,testAll
@@ -26,6 +27,7 @@ import           HIndent.Styles.ChrisDone (chrisDone)
 import           HIndent.Styles.Fundamental (fundamental)
 import           HIndent.Styles.Gibiansky (gibiansky)
 import           HIndent.Styles.JohanTibell (johanTibell)
+import           HIndent.Styles.TonyDay (tonyDay)
 import           HIndent.Types
 
 import           Control.Monad.State.Strict
@@ -106,7 +108,7 @@ testAst x =
 -- | Styles list, useful for programmatically choosing.
 styles :: [Style]
 styles =
-  [fundamental,chrisDone,johanTibell,gibiansky]
+  [fundamental,chrisDone,johanTibell,gibiansky,tonyDay]
 
 -- | Annotate the AST with comments.
 annotateComments :: forall ast. (Data (ast NodeInfo),Traversable ast,Annotated ast)

--- a/src/HIndent/Styles/TonyDay.hs
+++ b/src/HIndent/Styles/TonyDay.hs
@@ -1,0 +1,226 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+
+{-|
+  This style is intended to be used on entire modules. It:
+  - sorts pragmas and removes duplicates
+  - converts single-line multiple pramga declarations into multiple lines
+  - sorts import declarations and removes duplicates
+  - adds a newline between functions
+  - otherwise adopts ChrisDone style.
+-}
+
+module HIndent.Styles.TonyDay where
+
+import HIndent.Pretty
+import HIndent.Styles.ChrisDone
+import HIndent.Types
+
+import Control.Monad.State.Strict hiding (state)
+import Data.List
+import Language.Haskell.Exts.Annotated hiding (Style,prettyPrint,Pretty,style,parse)
+
+-- | Empty state.
+data State = State
+
+-- | The printer style.
+tonyDay :: Style
+tonyDay =
+  Style {styleName = "tony-day"
+        ,styleAuthor = "Tony Day"
+        ,styleDescription = "Cleans up a module, using ChrisDone style for lower level."
+        ,styleInitialState = HIndent.Styles.ChrisDone.State
+        ,styleExtenders =
+           [Extender HIndent.Styles.ChrisDone.exp
+           ,Extender fieldupdate
+           ,Extender rhs
+           ,Extender contextualGuardedRhs
+           ,Extender stmt
+           ,Extender decl'
+           ,Extender module']
+        ,styleDefConfig =
+           defaultConfig {configMaxColumns = 80
+                         ,configIndentSpaces = 2}}
+
+type Extend f = forall t. t -> f NodeInfo -> Printer ()
+
+{-|
+  Outputs 2 new lines.
+  This is meant to represent a section separator.  Some sectional ideas include:
+  - separation of import declarations (not yet implemented) - so that sorting can occur within sectional boundaries
+  - separation of module exports into logical units, often denoted by haddock (not yet implemented)
+  - separation of discrete function declaration+body 
+-}
+sepSection :: MonadState PrintState m => m ()
+sepSection =
+  do write "\n\n"
+     modify (\s -> s {psNewline = True})
+
+-- | changes annotations to () so that show can be used for comparisons
+bare :: (Annotated ast) => ast a -> ast ()
+bare src = void src
+
+-- | listify's single-line multiple pragmas
+listifyPragma :: ModulePragma a -> [ModulePragma a]
+listifyPragma (LanguagePragma a xs) = fmap (\x -> LanguagePragma a [x]) xs
+listifyPragma (OptionsPragma a tool str) =
+  fmap (OptionsPragma a tool) (words str)
+listifyPragma p@(AnnModulePragma _ _) = [p]
+
+-- | pragma comparison (uses show in part)
+comparePragmas :: (Show a) => ModulePragma a -> ModulePragma a -> Ordering
+comparePragmas (LanguagePragma{})    (OptionsPragma{})     = LT
+comparePragmas (LanguagePragma{})    (AnnModulePragma{})   = LT
+comparePragmas (OptionsPragma{})     (AnnModulePragma{})   = LT
+comparePragmas (OptionsPragma{})     (LanguagePragma{})    = GT
+comparePragmas (AnnModulePragma{})   (LanguagePragma{})    = GT
+comparePragmas (AnnModulePragma{})   (OptionsPragma{})     = GT
+comparePragmas (LanguagePragma _ []) (LanguagePragma _ []) = EQ
+comparePragmas (LanguagePragma _ []) (LanguagePragma{})    = LT
+comparePragmas (LanguagePragma{})    (LanguagePragma _ []) = GT
+comparePragmas (LanguagePragma _ (Symbol{}:_))
+                    (LanguagePragma _ (Ident{}:_)) = LT
+comparePragmas (LanguagePragma _ (Ident{}:_))
+                    (LanguagePragma _ (Symbol{}:_)) = GT
+comparePragmas (LanguagePragma _ (Ident _ n:_))
+                    (LanguagePragma _ (Ident _ n':_)) = compare n n'
+comparePragmas (LanguagePragma _ (Symbol _ n:_))
+                    (LanguagePragma _ (Symbol _ n':_)) = compare n n'
+comparePragmas
+  (OptionsPragma _ Nothing _)
+  (OptionsPragma _ (Just _) _) = LT
+comparePragmas
+  (OptionsPragma _ (Just _) _)
+  (OptionsPragma _ Nothing _) = GT
+comparePragmas
+  (OptionsPragma _ Nothing s)
+  (OptionsPragma _ Nothing s') = compare s s'
+comparePragmas
+  (OptionsPragma _ (Just t) s)
+  (OptionsPragma _ (Just t') s') =
+    case compare t t' of
+     LT -> LT
+     GT -> GT
+     EQ -> compare s s'
+comparePragmas
+  (AnnModulePragma _ s)
+  (AnnModulePragma _ s') = compareAnnotation s s'
+
+-- | annotation pragma comparison
+compareAnnotation :: Annotation a -> Annotation a1 -> Ordering
+compareAnnotation (Ann{})       (TypeAnn{})   = LT
+compareAnnotation (Ann{})       (ModuleAnn{}) = LT 
+compareAnnotation (ModuleAnn{}) (Ann{})       = LT
+compareAnnotation (ModuleAnn{}) (TypeAnn{})   = GT
+compareAnnotation (TypeAnn{})   (Ann{})       = GT
+compareAnnotation (TypeAnn{})   (ModuleAnn{}) = GT
+compareAnnotation (Ann _ (Ident{}) _) (Ann _ (Symbol{}) _) = LT
+compareAnnotation (Ann _ (Symbol{}) _) (Ann _ (Ident{}) _) = GT
+compareAnnotation (Ann _ (Ident _ s) e) (Ann _ (Ident _ s') e') =
+  case compare s s' of
+     LT -> LT
+     GT -> GT
+     EQ -> compare (show $ bare e) (show $ bare e')
+compareAnnotation (Ann _ (Symbol _ s) e) (Ann _ (Symbol _ s') e') =
+  case compare s s' of
+     LT -> LT
+     GT -> GT
+     EQ -> compare (show $ bare e) (show $ bare e')
+compareAnnotation (TypeAnn _ (Ident{}) _) (TypeAnn _ (Symbol{}) _) = LT
+compareAnnotation (TypeAnn _ (Symbol{}) _) (TypeAnn _ (Ident{}) _) = GT
+compareAnnotation (TypeAnn _ (Ident _ s) e) (TypeAnn _ (Ident _ s') e') =
+  case compare s s' of
+     LT -> LT
+     GT -> GT
+     EQ -> compare (show $ bare e) (show $ bare e')
+compareAnnotation (TypeAnn _ (Symbol _ s) e) (TypeAnn _ (Symbol _ s') e') =
+  case compare s s' of
+     LT -> LT
+     GT -> GT
+     EQ -> compare (show $ bare e) (show $ bare e')
+compareAnnotation (ModuleAnn _ e) (ModuleAnn _ e') =
+  compare (show $ bare e) (show $ bare e')
+
+-- | pragma equality
+eqPragma :: (Show a) => ModulePragma a -> ModulePragma a -> Bool
+eqPragma x x' =
+  case comparePragmas x x' of
+   EQ -> True
+   _ -> False
+
+-- | sorts and removes duplicate pragmas
+nubPragmas :: (Show a) => [ModulePragma a] -> [ModulePragma a]
+nubPragmas = fmap head . groupBy eqPragma . sortBy comparePragmas
+
+-- | import declaration comparison (uses show in part)
+compareImports :: ImportDecl a -> ImportDecl a -> Ordering
+compareImports (ImportDecl _ (ModuleName _ name) q src safe pkg as specs)
+               (ImportDecl _ (ModuleName _ name') q' src' safe' pkg' as' specs') =
+  case compare name name' of
+   GT -> GT
+   LT -> LT
+   EQ -> case compare q q' of
+     GT -> GT
+     LT -> LT
+     EQ -> case (specs,specs') of
+            (Nothing, Just _) -> LT
+            (Just _, Nothing) -> GT
+            _ -> case compare (show $ fmap bare specs) (show $ fmap bare specs') of
+              GT -> GT
+              LT -> LT
+              EQ -> case compare (show $ fmap bare as) (show $ fmap bare as') of
+                GT -> LT
+                LT -> GT
+                EQ -> compare (q,src,safe,pkg) (q',src',safe',pkg')
+
+-- | import declaration equality
+eqImports :: (Show a) => ImportDecl a -> ImportDecl a -> Bool
+eqImports x x' =
+  case compareImports x x' of
+   EQ -> True
+   _ -> False
+
+-- | sorts imports and removes duplicates
+nubImports :: (Show a) => [ImportDecl a] -> [ImportDecl a]
+nubImports = fmap head . groupBy eqImports . sortBy compareImports
+
+-- | cleans up pragmas and imports
+clean :: (Show a) => Module a -> Module a
+clean (Module a mayModHead pragmas imps decls) =
+  Module a mayModHead pragmas' imps' decls
+  where
+    pragmas' = nubPragmas $ concat (fmap listifyPragma pragmas)
+    imps'    = nubImports imps
+clean m = m
+
+-- | cleans up a module, and opinionated macro-format
+module' :: t -> Module NodeInfo -> Printer ()
+module' _ x = let x' = clean x in
+    case x' of
+      Module _ mayModHead pragmas imps decls ->
+        do
+          inter newline (fmap pretty pragmas)
+          unless (null pragmas) sepSection
+          case mayModHead of
+             Nothing -> return ()
+             Just modHead -> do
+               pretty modHead
+               unless (null imps && null decls) sepSection
+          inter newline (fmap pretty imps)
+          unless (null decls) sepSection
+          inter newline (fmap pretty decls)
+      XmlPage{} ->
+        error "FIXME: No implementation for XmlPage."
+      XmlHybrid{} ->
+        error "FIXME: No implementation for XmlHybrid."
+
+-- | adds an extra newline between declarations, unless it's a TypeSig
+decl' :: Extend Decl
+decl' s x = do
+  decl s x
+  when (notSig x) newline
+    where
+      notSig (TypeSig{}) = False
+      notSig _ = True

--- a/test/tony-day/expected/expected1.hs
+++ b/test/tony-day/expected/expected1.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+-- top comment
+module Test1 where
+
+import Control.Monad
+import Control.Monad (unless)
+import Control.Monad (when)
+import qualified Data.Foldable as F
+-- import Control.Lens hiding (each)
+-- import Data.List
+import Data.Monoid
+import HIndent
+import qualified HIndent
+import qualified HIndent as H
+import HIndent.Styles.TonyDay
+import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts.Annotated
+       hiding (Style, prettyPrint, Pretty, style, parse)
+
+-- floating between imps and decls
+-- before decl1
+x1 = 1
+
+-- before decl2
+x2 = 2
+-- trailing

--- a/test/tony-day/expected/expected2.hs
+++ b/test/tony-day/expected/expected2.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Test1 where
+
+import HIndent
+
+x1 = 1

--- a/test/tony-day/tests/test1.hs
+++ b/test/tony-day/tests/test1.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings, MultiWayIf #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-type-defaults #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults -fno-warn-name-shadowing #-}
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+-- top comment
+
+module Test1 where
+
+import qualified HIndent
+import HIndent
+import qualified HIndent as H
+import HIndent.Styles.TonyDay
+import           Language.Haskell.Exts.Annotated
+import           Language.Haskell.Exts.Annotated hiding (Style,prettyPrint,Pretty,style,parse)
+import Control.Monad
+import Control.Monad (unless)
+import Control.Monad (when)
+
+import qualified Data.Foldable as F
+-- import Control.Lens hiding (each)
+-- import Data.List
+import Data.Monoid
+
+-- floating between imps and decls
+
+-- before decl1
+x1=1
+-- before decl2
+x2=2
+-- trailing
+

--- a/test/tony-day/tests/test2.hs
+++ b/test/tony-day/tests/test2.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Test1 where
+
+import HIndent
+
+x1=1


### PR DESCRIPTION
The new style:
- adds an opinionated way to reformat an entire module
- cleans up pragmas and imports
- uses chrisDone for everything else (I'm not opinionated on this choice).

An alternative would be to integrate these ideas into the main code:
- argue that my module extension is idiomatic
- incorporate the cleanup's in the main code
- add a flag to Main.hs such as --cleanup, so that any other style can be used together with the cleanup idea.

More generally, there is some mis-match between applying a style to an entire module/file/string and applying a style to chunks (eg the test framework is hard-coded like that).  Hence the addition of hindent-reformat-module.

Thoughts?