### PR TITLE
Fixes for whole-module formatting

### DIFF
--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -2,18 +2,18 @@
 
 module HIndent.Styles.Gibiansky where
 
-import Data.Foldable
-import Control.Applicative((<$>))
-import Control.Monad (unless, when, replicateM_)
-import Control.Monad.State (gets, get, put)
+import           Data.Foldable
+import           Control.Applicative ((<$>))
+import           Control.Monad (unless, when, replicateM_)
+import           Control.Monad.State (gets, get, put)
 
-import HIndent.Pretty
-import HIndent.Types
+import           HIndent.Pretty
+import           HIndent.Types
 
-import Language.Haskell.Exts.Annotated.Syntax
-import Language.Haskell.Exts.SrcLoc
-import Language.Haskell.Exts.Comments
-import Prelude hiding (exp, all, mapM_, minimum, and, maximum)
+import           Language.Haskell.Exts.Annotated.Syntax
+import           Language.Haskell.Exts.SrcLoc
+import           Language.Haskell.Exts.Comments
+import           Prelude hiding (exp, all, mapM_, minimum, and, maximum)
 
 -- | Empty state.
 data State = State
@@ -84,10 +84,12 @@ type Extend f = forall t. t -> f NodeInfo -> Printer ()
 -- | Format whole modules.
 modl :: Extend Module
 modl _ (Module _ mayModHead pragmas imps decls) = do
+  onSeparateLines pragmas
+
   forM_ mayModHead $ \modHead -> do
       pretty modHead
       unless (null pragmas && null imps && null decls) newline
-  onSeparateLines pragmas
+
   onSeparateLines imps
   onSeparateLines decls
 modl _ m = prettyNoExt m

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -277,14 +277,10 @@ appExpr app@(App _ f x) = do
 appExpr _ = error "Not an app"
 
 doExpr :: Exp NodeInfo -> Printer ()
-doExpr (Do _ stmts@(first:rest)) = do
+doExpr (Do _ stmts) = do
   write "do"
   newline
-  indented 2 $ do
-    pretty first
-    forM_ (zip stmts rest) $ \(prev, cur) -> do
-      replicateM_ (max 1 $ lineDelta cur prev) newline
-      pretty cur
+  indented 2 $ onSeparateLines stmts
 doExpr _ = error "Not a do"
 
 listExpr :: Exp NodeInfo -> Printer ()
@@ -595,12 +591,9 @@ funBody pat rhs mbinds = do
       indented indentSpaces $ writeWhereBinds binds
 
 writeWhereBinds :: Binds NodeInfo -> Printer ()
-writeWhereBinds ds@(BDecls _ binds@(first:rest)) = do
+writeWhereBinds ds@(BDecls _ binds) = do
   printComments Before ds
-  pretty first
-  forM_ (zip binds rest) $ \(prev, cur) -> do
-    replicateM_ (max 1 $ lineDelta cur prev) newline
-    pretty cur
+  onSeparateLines binds
 writeWhereBinds binds = prettyNoExt binds
 
 onSeparateLines :: (Pretty ast, Annotated ast) => [ast NodeInfo] -> Printer ()

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -39,6 +39,7 @@ gibiansky =
                            , Extender moduleHead
                            , Extender exportList
                            , Extender fieldUpdate
+                           , Extender pragmas
                            ]
         , styleDefConfig =
            defaultConfig { configMaxColumns = 100
@@ -93,6 +94,13 @@ modl _ (Module _ mayModHead pragmas imps decls) = do
   onSeparateLines imps
   onSeparateLines decls
 modl _ m = prettyNoExt m
+
+pragmas :: Extend ModulePragma
+pragmas _ (LanguagePragma _ names) = do
+  write "{-# LANGUAGE "
+  inter (write ", ") $ map pretty names
+  write " #-}"
+pragmas _ p = prettyNoExt p
 
 -- | Format import statements.
 imp :: Extend ImportDecl

--- a/test/gibiansky/expected/24.exp
+++ b/test/gibiansky/expected/24.exp
@@ -1,0 +1,3 @@
+import           A
+>
+import           B

--- a/test/gibiansky/expected/24.exp
+++ b/test/gibiansky/expected/24.exp
@@ -1,3 +1,5 @@
 import           A
 >
 import           B
+
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, RecordWildCards, RankNTypes #-}

--- a/test/gibiansky/tests/24.test
+++ b/test/gibiansky/tests/24.test
@@ -1,3 +1,6 @@
 import A
 >
 import B
+
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, RecordWildCards, RankNTypes #-}
+>

--- a/test/gibiansky/tests/24.test
+++ b/test/gibiansky/tests/24.test
@@ -1,0 +1,3 @@
+import A
+>
+import B


### PR DESCRIPTION
This allows you to run `hindent` on an entire module, or blocks of import statements. It involves a few fixes:

- Respect user spacing of all the above.
- Pragmas are printed before module headers in the `gibiansky` style. This should probably be changed in the default style as well, though.
- Fixing issue with language pragmas being arbitrarily split onto several lines.