### PR TITLE
fix treatment of an inline where it starts on a new line

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -139,6 +139,8 @@ printComment mayNodespan (ComInfo (Comment inline cspan str) _) =
         then do write "{-"
                 string str
                 write "-}"
+                when (1 == srcSpanStartColumn cspan) $
+                  modify (\s -> s {psEolComment = True})
         else do write "--"
                 string str
                 modify (\s ->


### PR DESCRIPTION
An inline comment above a declaration renders on the same line:

    λ> test fundamental . Text.pack $ "{-| x2 comment -}\nx2=2"
    {-| x2 comment -}x2 = 
      2

After change:

    λ> test fundamental . Text.pack $ "{-| x2 comment -}\nx2=2"
    {-| x2 comment -}
    x2 = 
      2

I wasn't exactly sure if using srcSpanStartColumn == 1 was idiomatic, but the tests passed.
