### PR TITLE
Make attemptSingleLine regect a single with breaks

### DIFF
--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -67,7 +67,7 @@ prettyPrint style m =
   psOutput (execState (runPrinter m)
                       (case style of
                          Style _name _author _desc st extenders config ->
-                           PrintState 0 mempty False 0 1 st extenders config False False))
+                           PrintState 0 mempty mempty False 0 1 st extenders config False False))
 
 -- | Parse mode, includes all extensions, doesn't assume any fixities.
 parseMode :: ParseMode

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -145,6 +145,7 @@ printComment mayNodespan (ComInfo (Comment inline cspan str) _) =
                 string str
                 modify (\s ->
                           s {psEolComment = True})
+                newline
 
 -- | Pretty print using HSE's own printer. The 'P.Pretty' class here
 -- is HSE's.

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -312,7 +312,7 @@ doExpr :: Exp NodeInfo -> Printer ()
 doExpr (Do _ stmts) = do
   write "do"
   newline
-  indented 2 $ onSeparateLines stmts
+  indented indentSpaces $ onSeparateLines stmts
 doExpr _ = error "Not a do"
 
 listExpr :: Exp NodeInfo -> Printer ()

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -434,8 +434,7 @@ lambdaExpr (Lambda _ pats exp) = do
   write " ->"
   attemptSingleLine (write " " >> pretty exp) $ do
     newline
-    indentOnce
-    pretty exp
+    indented indentSpaces $ pretty exp
 lambdaExpr _ = error "Not a lambda"
 
 caseExpr :: Exp NodeInfo -> Printer ()

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -65,12 +65,16 @@ attemptSingleLine :: Printer a -> Printer a -> Printer a
 attemptSingleLine single multiple = do
   -- Try printing on one line.
   prevState <- get
+  prevLine <- getLineNum
   result <- single
 
   --  If it doesn't fit, reprint on multiple lines.
+  --  It doesn't fit if it is forced to go over the column limit or wraps
+  --  itself onto another line
+  line <- getLineNum
   col <- getColumn
   maxColumns <- configMaxColumns <$> gets psConfig
-  if col > maxColumns
+  if col > maxColumns || prevLine /= line
     then do
       put prevState
       multiple

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -37,6 +37,7 @@ newtype Printer a =
 data PrintState =
   forall s. PrintState {psIndentLevel :: !Int64 -- ^ Current indentation level.
                        ,psOutput :: !Builder -- ^ The current output.
+                       ,psPreviousLineLengths :: ![Int64] -- ^ The line lengths starting at the most recently written
                        ,psNewline :: !Bool -- ^ Just outputted a newline?
                        ,psColumn :: !Int64 -- ^ Current column.
                        ,psLine :: !Int64 -- ^ Current line number.
@@ -48,7 +49,7 @@ data PrintState =
                        }
 
 instance Eq PrintState where
-  PrintState ilevel out newline col line _ _ _ eolc inc == PrintState ilevel' out' newline' col' line' _ _ _ eolc' inc' =
+  PrintState ilevel out _ newline col line _ _ _ eolc inc == PrintState ilevel' out' _ newline' col' line' _ _ _ eolc' inc' =
     (ilevel,out,newline,col,line,eolc, inc) == (ilevel',out',newline',col',line',eolc', inc')
 
 -- | A printer extender. Takes as argument the user state that the


### PR DESCRIPTION
`attemptSingleLine` now checks that not only does `single` not end up over
budget on columns, but that it also doesn't insert a line break of its
own.