### PR TITLE
Keep comments between case alternates; fixes #104

### DIFF
--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -468,9 +468,11 @@ writeCaseAlts alts = do
     case alts of 
       [] -> return ()
       first:rest -> do
+        printComments Before first
         prettyPr first
         forM_ (zip alts rest) $ \(prev, cur) -> do
           replicateM_ (max 1 $ lineDelta cur prev) newline
+          printComments Before cur
           prettyPr cur
 
   where

--- a/test/gibiansky/expected/27.exp
+++ b/test/gibiansky/expected/27.exp
@@ -1,0 +1,27 @@
+case x of
+  -- First
+  x -> y
+
+case x of
+  -- First
+  x -> y
+>
+  -- Second
+  x -> y
+
+case x of
+  -- First
+  x -> y
+>
+  -- Second
+  x -> y
+>
+  -- Second
+  x -> y
+
+case x of
+  -- First
+  x -> y
+>
+  -- Second
+  x -> y

--- a/test/gibiansky/tests/27.test
+++ b/test/gibiansky/tests/27.test
@@ -1,0 +1,28 @@
+case x of
+  -- First
+  x -> y
+
+case x of
+  -- First
+  x -> y
+>
+  -- Second
+  x -> y
+
+case x of
+  -- First
+  x -> y
+>
+  -- Second
+  x -> y
+>
+  -- Second
+  x -> y
+
+case x of
+  -- First
+  x -> y
+>
+  -- Second
+>
+  x -> y


### PR DESCRIPTION
Only affects `gibiansky` style. Will merge once Travis validates it.