### PR TITLE
Adding support for comment reformatting

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -100,12 +100,12 @@ pretty a =
            depend
              (case listToMaybe (mapMaybe (makePrinter s) es) of
                 Just (Printer m) ->
-                  modify (\s ->
-                            fromMaybe s
-                                      (runIdentity (runMaybeT (execStateT m s))))
+                  modify (\s' ->
+                            fromMaybe s'
+                                      (runIdentity (runMaybeT (execStateT m s'))))
                 Nothing -> prettyNoExt a)
              (printComments After a)
-  where makePrinter s (Extender f) =
+  where makePrinter _ (Extender f) =
           case cast a of
             Just v -> Just (f v)
             Nothing -> Nothing

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -123,11 +123,10 @@ printComments :: (Pretty ast,MonadState (PrintState s) m)
               => ComInfoLocation -> ast NodeInfo -> m ()
 printComments loc' ast = do
   preprocessor <- gets psCommentPreprocessor
-  config <- gets psConfig
 
   let correctLocation comment = comInfoLocation comment == Just loc'
       commentsWithLocation = filter correctLocation (nodeInfoComments info)
-      comments = preprocessor config $ map comInfoComment commentsWithLocation
+  comments <- preprocessor $ map comInfoComment commentsWithLocation
 
   forM_ comments $ \comment -> do
     -- Preceeding comments must have a newline before them.

--- a/src/HIndent/Styles/ChrisDone.hs
+++ b/src/HIndent/Styles/ChrisDone.hs
@@ -54,7 +54,7 @@ chrisDone =
         ,styleDefConfig =
            defaultConfig {configMaxColumns = 80
                          ,configIndentSpaces = 2}
-        ,styleCommentPreprocessor = const id}
+        ,styleCommentPreprocessor = return}
 
 --------------------------------------------------------------------------------
 -- Extenders

--- a/src/HIndent/Styles/ChrisDone.hs
+++ b/src/HIndent/Styles/ChrisDone.hs
@@ -53,7 +53,8 @@ chrisDone =
            ,Extender decl]
         ,styleDefConfig =
            defaultConfig {configMaxColumns = 80
-                         ,configIndentSpaces = 2}}
+                         ,configIndentSpaces = 2}
+        ,styleCommentPreprocessor = const id}
 
 --------------------------------------------------------------------------------
 -- Extenders

--- a/src/HIndent/Styles/Fundamental.hs
+++ b/src/HIndent/Styles/Fundamental.hs
@@ -22,4 +22,4 @@ fundamental =
         ,styleInitialState = State
         ,styleExtenders = []
         ,styleDefConfig = def
-        ,styleCommentPreprocessor = const id}
+        ,styleCommentPreprocessor = return}

--- a/src/HIndent/Styles/Fundamental.hs
+++ b/src/HIndent/Styles/Fundamental.hs
@@ -21,4 +21,5 @@ fundamental =
         ,styleDescription = "This style adds no extensions to the built-in printer."
         ,styleInitialState = State
         ,styleExtenders = []
-        ,styleDefConfig = def}
+        ,styleDefConfig = def
+        ,styleCommentPreprocessor = const id}

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -8,6 +8,7 @@ import           Control.Applicative ((<$>))
 import           Control.Monad (unless, when, replicateM_)
 import           Control.Monad.State (gets, get, put)
 import           Data.Maybe (isNothing)
+import           Data.List (unfoldr, isPrefixOf)
 
 import           HIndent.Pretty
 import           HIndent.Types
@@ -15,7 +16,7 @@ import           HIndent.Types
 import           Language.Haskell.Exts.Annotated.Syntax
 import           Language.Haskell.Exts.SrcLoc
 import           Language.Haskell.Exts.Comments
-import           Prelude hiding (exp, all, mapM_, minimum, and, maximum, any)
+import           Prelude hiding (exp, all, mapM_, minimum, and, maximum, concatMap, any)
 
 -- | Empty state.
 data State = State { gibianskyForceSingleLine :: Bool }
@@ -47,7 +48,96 @@ gibiansky = Style { styleName = "gibiansky"
                                                    , configIndentSpaces = indentSpaces
                                                    , configClearEmptyLines = True
                                                    }
+                  , styleCommentPreprocessor = commentPreprocessor
                   }
+
+-- Field accessor for Comment.
+commentContent :: Comment -> String
+commentContent (Comment _ _ content) = content
+
+-- Field accessor for Comment.
+commentSrcSpan :: Comment -> SrcSpan
+commentSrcSpan (Comment _ srcSpan _) = srcSpan
+
+commentPreprocessor :: Config -> [Comment] -> [Comment]
+commentPreprocessor config = concatMap mergeGroup . groupComments Nothing []
+  where
+    -- Group comments into blocks.
+    -- A comment block is the list of comments that are on consecutive lines,
+    -- and do not have an empty comment in between them. Empty comments are those with only whitespace.
+    -- Empty comments are in their own group.
+    groupComments :: Maybe Int -> [Comment] -> [Comment] -> [[Comment]]
+    groupComments nextLine accum (comment@(Comment multiline srcSpan str):comments)
+      | multiline || isWhitespace str || "  " `isPrefixOf` str = useAsSeparateCommentGroup
+      | isNothing nextLine || Just (srcSpanStartLine srcSpan) == nextLine = groupComments nextLine' (comment:accum) comments
+      | otherwise = currentGroupAsList ++ groupComments (Just $ srcSpanStartLine srcSpan + 1) [comment] comments
+      where
+        useAsSeparateCommentGroup = currentGroupAsList ++ [comment] : groupComments nextLine' [] comments
+        nextCommentStartLine = srcSpanStartLine $ commentSrcSpan $ head comments
+        currentGroupAsList | null accum = []
+                           | otherwise = [reverse accum]
+        nextLine' = 
+          case nextLine of
+            Just x -> Just (x + 1)
+            Nothing -> Just nextCommentStartLine
+    groupComments _ [] [] = []
+    groupComments _ accum [] = [reverse accum]
+
+    isWhitespace :: String -> Bool
+    isWhitespace = all (\x -> x == ' ' || x == '\t')
+
+    -- Merge a group of comments into one comment.
+    mergeGroup :: [Comment] -> [Comment]
+    mergeGroup [] = error "Empty comment group"
+    mergeGroup comments@[Comment True _ _] = comments
+    mergeGroup comments = 
+      let maxStartColumn = maximum $ map (srcSpanStartColumn . commentSrcSpan) comments
+          firstLine = srcSpanStartLine $ commentSrcSpan $ head comments
+          firstSrcSpan = commentSrcSpan $ head comments
+          commentLen = length ("--" :: String)
+
+          lineLen = fromIntegral (configMaxColumns config) - maxStartColumn - commentLen
+          content = breakCommentLines lineLen $ unlines (map commentContent comments)
+          srcSpanLines = map (firstLine +) [0 .. length content - 1]
+          srcSpans = map (\linum -> firstSrcSpan { srcSpanStartLine = linum, srcSpanEndLine = linum, srcSpanStartColumn = maxStartColumn }) srcSpanLines
+      in zipWith (Comment False) srcSpans content
+
+
+-- | Break a comment string into lines of a maximum character length.
+-- Each line starts with a space, mirroring the traditional way of writing comments:
+--
+--   -- Hello
+--   -- Note the space after the '-'
+breakCommentLines :: Int -> String -> [String]
+breakCommentLines maxLen str =
+  -- If we already have a line of the appropriate length, leave it alone.
+  -- This allows us to format stuff ourselves in some cases.
+  if length (lines str) == 1 && length str <= maxLen
+  then [reverse . dropWhile (== '\n') . reverse $ str]
+  else unfoldr unfolder (words str)
+
+  where
+    -- Generate successive lines, consuming the words iteratively.
+    unfolder :: [String] -> Maybe (String, [String])
+    unfolder [] = Nothing
+    unfolder ws = Just $ go maxLen [] ws
+      where
+        go :: Int                -- Characters remaining on the line to be used
+           -> [String]           -- Accumulator: The words used so far on this line
+           -> [String]           -- Unused words
+           -> (String, [String]) -- (Generated line, remaining words)
+        go remainingLen taken remainingWords =
+          case remainingWords of
+            -- If no more words remain, we're done
+            [] -> (generatedLine, [])
+            word:remWords ->
+              -- If the next word doesn't fit on this line, line break
+              let nextRemaining = remainingLen - length word - 1 in
+                if nextRemaining <= 0
+                then (generatedLine, remainingWords)
+                else go nextRemaining (word:taken) remWords
+          where
+            generatedLine = ' ' : unwords (reverse taken)
 
 -- | Number of spaces to indent by.
 indentSpaces :: Integral a => a

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -54,7 +54,7 @@ johanTibell =
         ,styleDefConfig =
            defaultConfig {configMaxColumns = 80
                          ,configIndentSpaces = 4}
-        ,styleCommentPreprocessor = const id}
+        ,styleCommentPreprocessor = return}
 
 --------------------------------------------------------------------------------
 -- Extenders

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -53,7 +53,8 @@ johanTibell =
            ]
         ,styleDefConfig =
            defaultConfig {configMaxColumns = 80
-                         ,configIndentSpaces = 4}}
+                         ,configIndentSpaces = 4}
+        ,styleCommentPreprocessor = const id}
 
 --------------------------------------------------------------------------------
 -- Extenders

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -50,10 +50,11 @@ data PrintState s =
              ,psEolComment :: !Bool -- ^ An end of line comment has just been outputted.
              ,psInsideCase :: !Bool -- ^ Whether we're in a case statement, used for Rhs printing.
              ,psParseMode :: !ParseMode -- ^ Mode used to parse the original AST.
+             ,psCommentPreprocessor :: Config -> [Comment] -> [Comment] -- ^ Preprocessor applied to comments on an AST before printing.
              }
 
 instance Eq (PrintState s) where
-  PrintState ilevel out newline col line _ _ _ eolc inc _ == PrintState ilevel' out' newline' col' line' _ _ _ eolc' inc' _ =
+  PrintState ilevel out newline col line _ _ _ eolc inc _pm _ == PrintState ilevel' out' newline' col' line' _ _ _ eolc' inc' _pm' _ =
     (ilevel,out,newline,col,line,eolc, inc) == (ilevel',out',newline',col',line',eolc', inc')
 
 -- | A printer extender. Takes as argument the user state that the
@@ -71,6 +72,7 @@ data Style =
                   ,styleInitialState :: !s -- ^ User state, if needed.
                   ,styleExtenders :: ![Extender s] -- ^ Extenders to the printer.
                   ,styleDefConfig :: !Config -- ^ Default config to use for this style.
+                  ,styleCommentPreprocessor :: Config -> [Comment] -> [Comment] -- ^ Preprocessor to use for comments.
                   }
 
 -- | Configurations shared among the different styles. Styles may pay

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -- | All types.
 
@@ -50,7 +51,7 @@ data PrintState s =
              ,psEolComment :: !Bool -- ^ An end of line comment has just been outputted.
              ,psInsideCase :: !Bool -- ^ Whether we're in a case statement, used for Rhs printing.
              ,psParseMode :: !ParseMode -- ^ Mode used to parse the original AST.
-             ,psCommentPreprocessor :: Config -> [Comment] -> [Comment] -- ^ Preprocessor applied to comments on an AST before printing.
+             ,psCommentPreprocessor :: forall m. MonadState (PrintState s) m => [Comment] -> m [Comment] -- ^ Preprocessor applied to comments on an AST before printing.
              }
 
 instance Eq (PrintState s) where
@@ -72,7 +73,7 @@ data Style =
                   ,styleInitialState :: !s -- ^ User state, if needed.
                   ,styleExtenders :: ![Extender s] -- ^ Extenders to the printer.
                   ,styleDefConfig :: !Config -- ^ Default config to use for this style.
-                  ,styleCommentPreprocessor :: Config -> [Comment] -> [Comment] -- ^ Preprocessor to use for comments.
+                  ,styleCommentPreprocessor :: forall s' m. MonadState (PrintState s') m => [Comment] -> m [Comment] -- ^ Preprocessor to use for comments.
                   }
 
 -- | Configurations shared among the different styles. Styles may pay

--- a/test/gibiansky/expected/11.exp
+++ b/test/gibiansky/expected/11.exp
@@ -3,12 +3,10 @@ data A = B             -- ^ hi
        | D Float       -- ^ hi
        | E Float Float -- ^ hi
 
-data A = B             -- ^ hi
-                       -- continuing the comment
+data A = B             -- ^ hi continuing the comment
        | C Int         -- ^ hi
        | D Float       -- ^ hi
-       | E Float Float -- ^ hi
-                       -- continuing the comment
+       | E Float Float -- ^ hi continuing the comment
 
 a =
   case x of
@@ -51,6 +49,5 @@ data X =
 data X =
        X
          { a :: Int    -- ^ hi
-         , b :: String -- ^ hi
-                       -- continued
+         , b :: String -- ^ hi continued
          }

--- a/test/gibiansky/expected/13.exp
+++ b/test/gibiansky/expected/13.exp
@@ -2,8 +2,7 @@ a = b
   where
     blah = blah
 
-    -- hello
-    -- bye
+    -- hello bye
     hello = hello
 
 a = b

--- a/test/gibiansky/expected/20.exp
+++ b/test/gibiansky/expected/20.exp
@@ -1,3 +1,2 @@
--- Comment 1
--- Comment 2
+-- Comment 1 Comment 2
 f x = x

--- a/test/gibiansky/expected/30.exp
+++ b/test/gibiansky/expected/30.exp
@@ -12,3 +12,11 @@ a = a
 Hello
 -}
 a = a
+
+type Maybe a = forall r. (a -> r) -> r -> r -- foo bar zot sdfs zot sdfs zot sdfs zot sdfs zot sdfs
+                                            -- zot sdfs zot sdfs zot sdfs zot sdfs
+
+type Maybe a = forall r. (a -> r)
+                      -> r
+                      -> r -- foo bar zot sdfs zot sdfs zot sdfs zot sdfs zot sdfs zot sdfs zot sdfs
+                           -- zot sdfs zot sdfs

--- a/test/gibiansky/expected/30.exp
+++ b/test/gibiansky/expected/30.exp
@@ -1,0 +1,14 @@
+-- Hello
+a = a
+
+-- Hello Hello
+a = a
+
+-- Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello
+-- Hello Hello Hello Hello Hello
+a = a
+
+{-
+Hello
+-}
+a = a

--- a/test/gibiansky/tests/11.test
+++ b/test/gibiansky/tests/11.test
@@ -3,12 +3,10 @@ data A = B             -- ^ hi
        | D Float       -- ^ hi
        | E Float Float -- ^ hi
 
-data A = B             -- ^ hi
-                       -- continuing the comment
+data A = B             -- ^ hi continuing the comment
        | C Int         -- ^ hi
        | D Float       -- ^ hi
-       | E Float Float -- ^ hi
-                       -- continuing the comment
+       | E Float Float -- ^ hi continuing the comment
 
 a = case x of
   Nothing -> 2
@@ -41,6 +39,5 @@ data X = X { a :: Int    -- ^ hi
            }
 
 data X = X { a :: Int    -- ^ hi
-           , b :: String -- ^ hi
-                         -- continued
+           , b :: String -- ^ hi continued
            }

--- a/test/gibiansky/tests/13.test
+++ b/test/gibiansky/tests/13.test
@@ -2,8 +2,7 @@ a = b
   where
     blah = blah
 
-    -- hello
-    -- bye
+    -- hello bye
     hello = hello
 
 a = b

--- a/test/gibiansky/tests/20.test
+++ b/test/gibiansky/tests/20.test
@@ -1,3 +1,2 @@
--- Comment 1
--- Comment 2
+-- Comment 1 Comment 2
 f x = x

--- a/test/gibiansky/tests/30.test
+++ b/test/gibiansky/tests/30.test
@@ -12,3 +12,14 @@ a = a
 Hello
 -}
 a = a
+
+type Maybe a = forall r. (a -> r) -> r -> r -- foo bar zot sdfs zot
+                                            -- sdfs zot sdfs zot sdfs
+                                            -- zot sdfs zot sdfs zot
+                                            -- sdfs zot sdfs zot sdfs
+
+type Maybe a = 
+  forall r. (a -> r) 
+            -> r 
+            -> r -- foo bar zot sdfs zot sdfs zot sdfs zot sdfs zot
+                 -- sdfs zot sdfs zot sdfs zot sdfs zot sdfs

--- a/test/gibiansky/tests/30.test
+++ b/test/gibiansky/tests/30.test
@@ -1,0 +1,14 @@
+-- Hello
+a = a
+
+-- Hello
+-- Hello
+a = a
+
+-- Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello Hello
+a = a
+
+{-
+Hello
+-}
+a = a


### PR DESCRIPTION
This PR implements comment reformatting; initial attempts to use the `Extender` system did not work (and i think that would be too complicated).

The comment reformatting is a function of type
```
Config -> [Comment] -> [Comment]
```
which can do whatever it wants to those comments.

I implemented it for the `gibiansky` style and made it a no-op for all other styles.