### PR TITLE
Implementing CPP parsing and processing for simple use cases

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 -- | Main entry point to hindent.


### PR DESCRIPTION
This implements a first pass for issue #109.

I tested it on a few IHaskell files that contain CPP, and it seems to be enough -- may require some workarounds, but I don't think I need anything else of `hindent` for my purposes.

Good to merge?