### PR TITLE
Tibbe style: make comma spacing in types consistent with comma spacing in terms.

### DIFF
--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -45,6 +45,7 @@ johanTibell =
         ,styleExtenders =
            [Extender decl
            ,Extender context
+           ,Extender typ
            ,Extender conDecl
            ,Extender exp
            ,Extender guardedRhs
@@ -228,6 +229,18 @@ context :: Context NodeInfo -> Printer s ()
 context (CxTuple _ asserts) =
   parens $ inter (comma >> space) $ map pretty asserts
 context ctx = prettyNoExt ctx
+
+unboxParens :: MonadState (PrintState s) m => m a -> m a
+unboxParens p =
+  depend (write "(# ")
+         (do v <- p
+             write " #)"
+             return v)
+
+typ :: Type NodeInfo -> Printer s ()
+typ (TyTuple _ Boxed types) = parens $ inter (write ", ") $ map pretty types
+typ (TyTuple _ Unboxed types) = unboxParens $ inter (write ", ") $ map pretty types
+typ ty = prettyNoExt ty
 
 -- | Specially format records. Indent where clauses only 2 spaces.
 decl :: Decl NodeInfo -> Printer s ()

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -44,6 +44,7 @@ johanTibell =
         ,styleInitialState = State
         ,styleExtenders =
            [Extender decl
+           ,Extender context
            ,Extender conDecl
            ,Extender exp
            ,Extender guardedRhs
@@ -222,11 +223,17 @@ exp (RecUpdate _ exp updates) = recUpdateExpr (pretty exp) updates
 exp (RecConstr _ qname updates) = recUpdateExpr (pretty qname) updates
 exp e = prettyNoExt e
 
+-- | Format contexts with spaces and commas between class constraints.
+context :: Context NodeInfo -> Printer s ()
+context (CxTuple _ asserts) =
+  parens $ inter (comma >> space) $ map pretty asserts
+context ctx = prettyNoExt ctx
+
 -- | Specially format records. Indent where clauses only 2 spaces.
 decl :: Decl NodeInfo -> Printer s ()
 -- | Pretty print type signatures like
 --
--- foo :: (Show x,Read x)
+-- foo :: (Show x, Read x)
 --     => (Foo -> Bar)
 --     -> Maybe Int
 --     -> (Char -> X -> Y)

--- a/test/johan-tibell/expected/5.exp
+++ b/test/johan-tibell/expected/5.exp
@@ -1,0 +1,7 @@
+fun :: (Class a, Class b)
+    => a -> b -> c
+
+fun :: (a, b, c) -> (a, b)
+
+fun :: (Class a, Class b)
+    => a -> (# d, e #) -> c

--- a/test/johan-tibell/tests/5.test
+++ b/test/johan-tibell/tests/5.test
@@ -1,0 +1,7 @@
+fun :: (Class a,Class b)
+    => a -> b -> c
+
+fun :: (a,b,c) -> (a,b)
+
+fun :: (Class a, Class b)
+    => a ->(# d,e #)-> c


### PR DESCRIPTION
Fixes #112