### PR TITLE
tibbe style: various fixes to do-notation, case-of and let-in.

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -48,6 +48,7 @@ module HIndent.Pretty
   , depend
   , dependBind
   , swing
+  , swingBy
   , getIndentSpaces
   , getColumnLimit
   -- * Predicates
@@ -421,6 +422,15 @@ swing a b =
      newline
      indentSpaces <- getIndentSpaces
      column (orig + indentSpaces) b
+
+-- | Swing the second printer below and indented with respect to the first by
+-- the specified amount.
+swingBy :: MonadState (PrintState s) m => Int64 -> m () -> m b -> m b
+swingBy i a b =
+  do orig <- gets psIndentLevel
+     a
+     newline
+     column (orig + i) b
 
 --------------------------------------------------------------------------------
 -- * Instances

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -222,6 +222,13 @@ exp (List _ es) =
                           (map pretty es))
 exp (RecUpdate _ exp updates) = recUpdateExpr (pretty exp) updates
 exp (RecConstr _ qname updates) = recUpdateExpr (pretty qname) updates
+exp (Let _ binds e) =
+  do newline   -- Make the let swing under.
+     depend (write "let ")
+            (do pretty binds
+                newline
+                indented (-4) (depend (write "in ")
+                                      (pretty e)))
 exp e = prettyNoExt e
 
 match :: Match NodeInfo -> Printer s ()

--- a/test/johan-tibell/expected/2.exp
+++ b/test/johan-tibell/expected/2.exp
@@ -1,5 +1,5 @@
 strToMonth :: String -> Int
 strToMonth month = case month of
-        "Jan" -> 1
-        "Feb" -> 2
-        _ -> error $ "Unknown month " ++ month
+    "Jan" -> 1
+    "Feb" -> 2
+    _ -> error $ "Unknown month " ++ month

--- a/test/johan-tibell/expected/6.exp
+++ b/test/johan-tibell/expected/6.exp
@@ -1,0 +1,19 @@
+f :: Int
+f x
+    | x <- Just x
+    , x <- Just x = 
+        case x of
+            Just x -> e
+    | otherwise = do
+        e
+  where
+    x = y
+
+g x = case x of
+    a -> x
+  where
+    foo = case x of
+        _ -> do
+            launchMissiles
+      where
+        y = 2

--- a/test/johan-tibell/expected/7.exp
+++ b/test/johan-tibell/expected/7.exp
@@ -1,0 +1,8 @@
+g x = 
+    let x = 1
+    in x
+  where
+    foo = 
+        let y = 2
+            z = 3
+        in y

--- a/test/johan-tibell/tests/6.test
+++ b/test/johan-tibell/tests/6.test
@@ -1,0 +1,15 @@
+f :: Int
+f x | x <- Just x
+    , x <- Just x = case x of
+         Just x -> e
+  | otherwise = do
+    e
+  where
+    x = y
+
+g x = case x of a -> x
+  where
+    foo = case x of
+        _ -> do launchMissiles
+      where
+        y = 2

--- a/test/johan-tibell/tests/7.test
+++ b/test/johan-tibell/tests/7.test
@@ -1,0 +1,3 @@
+g x = let x = 1 in x
+  where
+    foo = let y = 2; z = 3 in y


### PR DESCRIPTION
* where-clause: indent according to style (see commit msg).
* case-of: swing, the way do already is.
* do-notation: make indentation consistent.
* let-in: don't swing the body independently of the binds. Swing all of it as one unit.

Fixes #115

cc @tibbe