### PR TITLE
Add space before some patterns in lambdas

### DIFF
--- a/src/HIndent/Styles/ChrisDone.hs
+++ b/src/HIndent/Styles/ChrisDone.hs
@@ -265,13 +265,17 @@ exp (App _ op a) =
         flatten f' as = (f',as)
 -- | Lambdas are dependent if they can be.
 exp (Lambda _ ps b) =
-  depend (write "\\")
+  depend (write "\\" >> maybeSpace)
          (do spaced (map pretty ps)
              dependOrNewline
                (write " -> ")
                b
                (indented 1 .
                 pretty))
+  where maybeSpace = case ps of
+                       (PBangPat {}):_ -> space
+                       (PIrrPat {}):_ -> space
+                       _ -> return ()
 exp (Tuple _ boxed exps) =
   depend (write (case boxed of
                    Unboxed -> "(#"

--- a/test/chris-done/expected/20.exp
+++ b/test/chris-done/expected/20.exp
@@ -1,0 +1,2 @@
+f = \ ~a -> undefined
+f = \ !a -> undefined

--- a/test/chris-done/tests/20.test
+++ b/test/chris-done/tests/20.test
@@ -1,0 +1,2 @@
+f = \ ~a -> undefined
+f = \ !a -> undefined


### PR DESCRIPTION
Some patterns (namely `~` and `!`) require a space after the `\` of a lambda to work.