### PR TITLE
Prettyprint record patterns similarly to record updates

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -136,7 +136,7 @@ printComments loc' ast = do
 
     printComment (Just $ srcInfoSpan $ nodeInfoSpan info) comment
   where info = ann ast
- 
+
 
 -- | Pretty print a comment.
 printComment :: MonadState (PrintState s) m => Maybe SrcSpan -> Comment -> m ()
@@ -475,12 +475,13 @@ instance Pretty Pat where
                    write (case boxed of
                             Unboxed -> "#)"
                             Boxed -> ")"))
-      PList _ ps ->
-        brackets (commas (map pretty ps))
+      PList _ ps -> brackets (commas (map pretty ps))
       PParen _ e -> parens (pretty e)
       PRec _ qname fields ->
-        depend (pretty qname)
-               (braces (commas (map pretty fields)))
+        do indentSpaces <- getIndentSpaces
+           depend (pretty qname)
+                  (braces (prefixedLined ","
+                                         (map (indented indentSpaces . pretty) fields)))
       PAsPat _ n p ->
         depend (do pretty n
                    write "@")

--- a/src/HIndent/Styles/ChrisDone.hs
+++ b/src/HIndent/Styles/ChrisDone.hs
@@ -175,11 +175,13 @@ guardedrhs (GuardedRhs _ stmts e) =
                          do space
                             pretty p)
                       stmts)
-               dependOrNewline
-                 (write " = ")
-                 e
-                 (indented 1 .
-                  pretty))
+               let rhs =
+                     do write " = "
+                        pretty e
+               (fits,st) <- fitsOnOneLine rhs
+               if fits
+                  then put st
+                  else indented (-2) rhs)
 
 -- | I want guarded alts be dependent or newline.
 guardedalt :: GuardedRhs NodeInfo -> Printer t ()


### PR DESCRIPTION
Without patch:
```
gatherBangedBinds (L l bind:binds)
  | PatBind{pat_lhs = pat,pat_rhs = rhs,pat_rhs_ty = ty,pat_ticks = (ticks,lticks)} <- bind
```
vs with:
```
gatherBangedBinds (L l bind:binds)
  | PatBind{pat_lhs = pat
           ,pat_rhs = rhs
           ,pat_rhs_ty = ty
           ,pat_ticks = (ticks,lticks)} <- bind
```