### PR TITLE
Elaborated on the activation of hindent in the Emacs configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ buffer:
 To enable it, add the following to your init file:
 
 ```lisp
+(add-to-list 'load-path "/path/to/hindent/elisp")
+(require 'hindent)
 (add-hook 'haskell-mode-hook #'hindent-mode)
 ```
 


### PR DESCRIPTION
A minor change for the README.md; it does not suffice to add

    (add-hook 'haskell-mode-hook #'hindent-mode)

to your ~/.emacs, instead you need something like

    (add-to-list 'load-path "/path/to/hindent/elisp")
    (require 'hindent)
    (add-hook 'haskell-mode-hook #'hindent-mode)
