### PR TITLE
Replace flet with noflet

### DIFF
--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -4,7 +4,7 @@
 
 ;; Author: Chris Done <chrisdone@gmail.com>
 ;; URL: https://github.com/chrisdone/hindent
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((noflet "0.0.15"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 
 ;;; Code:
 
-(require 'cl-lib)
+(require 'noflet)
 
 (defcustom hindent-style
   "fundamental"
@@ -136,7 +136,7 @@ expected to work."
    ;; Otherwise we just do our line-based hack.
    (t
     (save-excursion
-      (let ((start (or (flet
+      (let ((start (or (noflet
                            ((jump ()
                                   (search-backward-regexp "^[^ \n]" nil t 1)
                                   (cond
@@ -150,7 +150,7 @@ expected to work."
                          (jump))
                        0))
             (end (progn (goto-char (1+ (point)))
-                        (or (flet
+                        (or (noflet
                                 ((jump ()
                                        (when (search-forward-regexp "[\n]+[^ \n]" nil t 1)
                                          (cond


### PR DESCRIPTION
This PR closes #128 by replacing the now obsolete `flet` usage with `noflet`. I opted to use the `noflet` package because it seemed like a pragmatic approach but I'm happy if the maintainers of `hindent` think an alternative solution would be more appropriate.

Here's what I did:

- added noflet as a package dep.
- removed cl-lib as a package dep.
- replaced flet with noflet.

Please note, I've never really hacked on an emacs package so please sanity check this PR.

