### PR TITLE
type equality is tilde, not Eq

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -573,7 +573,7 @@ instance Pretty Type where
            pretty right
       TyEquals _ left right ->
         do pretty left
-           write " == "
+           write " ~ "
            pretty right
       ty@TyPromoted{} -> pretty' ty
       TySplice{} -> error "FIXME: No implementation for TySplice."


### PR DESCRIPTION
For fixing #177 

/cc @mgsloan @chrisdone 