### PR TITLE
Felxible, non-deterministic pretty printing

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -47,6 +47,7 @@ library
                    , data-default
                    , haskell-src-exts >= 1.17
                    , monad-loops
+                   , monad-dijkstra
                    , mtl
                    , text
                    , transformers

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -182,13 +182,12 @@ prettyPrint mode' style m comments =
 -- | Pretty print the given printable thing.
 runPrinterStyle
   :: ParseMode -> Style -> (forall s. Printer s ()) -> Builder
-runPrinterStyle mode' (Style _name _author _desc st extenders config preprocessor) m =
+runPrinterStyle mode' (Style _name _author _desc st extenders config preprocessor penalty) m =
   maybe (error "Printer failed with mzero call.")
         psOutput
-        (snd <$>
-         execPrinter
+        (snd <$> execPrinter
            m
-           (PrintState 0 mempty False 0 1 st extenders config False False mode' preprocessor))
+           (PrintState 0 mempty False 0 1 st extenders config False False mode' preprocessor penalty))
 
 -- | Parse mode, includes all extensions, doesn't assume any fixities.
 parseMode :: ParseMode

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -185,7 +185,8 @@ runPrinterStyle
 runPrinterStyle mode' (Style _name _author _desc st extenders config preprocessor) m =
   maybe (error "Printer failed with mzero call.")
         psOutput
-        (execPrinter
+        (snd <$>
+         execPrinter
            m
            (PrintState 0 mempty False 0 1 st extenders config False False mode' preprocessor))
 

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -36,9 +36,7 @@ import           HIndent.Types
 
 import           Control.Applicative ((<$>))
 import           Control.Monad.State.Strict
-import           Control.Monad.Trans.Maybe
 import           Data.Function (on)
-import           Data.Functor.Identity
 import           Data.List
 import           Data.List (groupBy, intersperse)
 import           Data.Maybe (fromMaybe)
@@ -182,14 +180,14 @@ prettyPrint mode' style m comments =
                       pretty ast))
 
 -- | Pretty print the given printable thing.
-runPrinterStyle :: ParseMode -> Style -> (forall s. Printer s ()) -> Builder
+runPrinterStyle
+  :: ParseMode -> Style -> (forall s. Printer s ()) -> Builder
 runPrinterStyle mode' (Style _name _author _desc st extenders config preprocessor) m =
   maybe (error "Printer failed with mzero call.")
         psOutput
-        (runIdentity
-           (runMaybeT (execStateT
-                         (runPrinter m)
-                         (PrintState 0 mempty False 0 1 st extenders config False False mode' preprocessor))))
+        (execPrinter
+           m
+           (PrintState 0 mempty False 0 1 st extenders config False False mode' preprocessor))
 
 -- | Parse mode, includes all extensions, doesn't assume any fixities.
 parseMode :: ParseMode

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -61,8 +61,6 @@ module HIndent.Pretty
   )
   where
 
-import           Control.Monad.Trans.Maybe
-import           Data.Functor.Identity
 import           HIndent.Types
 
 import           Language.Haskell.Exts.Comments
@@ -100,12 +98,7 @@ pretty a =
          do
            printComments Before a
            depend
-             (case listToMaybe (mapMaybe (makePrinter s) es) of
-                Just (Printer m) ->
-                  modify (\s' ->
-                            fromMaybe s'
-                                      (runIdentity (runMaybeT (execStateT m s'))))
-                Nothing -> prettyNoExt a)
+             (fromMaybe (prettyNoExt a) $ listToMaybe (mapMaybe (makePrinter s) es))
              (printComments After a)
   where makePrinter _ (Extender f) =
           case cast a of

--- a/src/HIndent/Styles/ChrisDone.hs
+++ b/src/HIndent/Styles/ChrisDone.hs
@@ -414,8 +414,7 @@ isShort p =
 
 -- | Is the given expression "small"? I.e. does it fit on one line and
 -- under 'smallColumnLimit' columns.
-isSmall :: MonadState (PrintState t) m
-        => m a -> m (Bool,PrintState t)
+isSmall :: Printer s a -> Printer s (Bool,PrintState s)
 isSmall p =
   do line <- gets psLine
      (_,st) <- sandbox p
@@ -423,8 +422,7 @@ isSmall p =
 
 -- | Is the given expression "small"? I.e. does it fit under
 -- 'smallColumnLimit' columns.
-isSmallFitting :: MonadState (PrintState t) m
-               => m a -> m (Bool,PrintState t)
+isSmallFitting :: Printer s a -> Printer s (Bool,PrintState s)
 isSmallFitting p =
   do (_,st) <- sandbox p
      return (psColumn st < smallColumnLimit,st)
@@ -448,7 +446,7 @@ isFlat (RightSection _ _ e) = isFlat e
 isFlat _ = False
 
 -- | Does printing the given thing overflow column limit? (e.g. 80)
-fitsOnOneLine :: MonadState (PrintState s) m => m a -> m (Bool,PrintState s)
+fitsOnOneLine :: Printer s a -> Printer s (Bool,PrintState s)
 fitsOnOneLine p =
   do line <- gets psLine
      (_,st) <- sandbox p

--- a/src/HIndent/Styles/ChrisDone.hs
+++ b/src/HIndent/Styles/ChrisDone.hs
@@ -56,7 +56,8 @@ chrisDone =
         ,styleDefConfig =
            defaultConfig {configMaxColumns = 80
                          ,configIndentSpaces = 2}
-        ,styleCommentPreprocessor = return}
+        ,styleCommentPreprocessor = return
+        ,styleLinePenalty = defaultLinePenalty}
 
 --------------------------------------------------------------------------------
 -- Extenders

--- a/src/HIndent/Styles/Cramer.hs
+++ b/src/HIndent/Styles/Cramer.hs
@@ -74,7 +74,8 @@ cramer =
            defaultConfig {configMaxColumns = 80
                          ,configIndentSpaces = 4
                          ,configClearEmptyLines = True}
-        ,styleCommentPreprocessor = return}
+        ,styleCommentPreprocessor = return
+        ,styleLinePenalty = defaultLinePenalty}
 
 --------------------------------------------------------------------------------
 -- Helper

--- a/src/HIndent/Styles/Cramer.hs
+++ b/src/HIndent/Styles/Cramer.hs
@@ -7,7 +7,7 @@
 module HIndent.Styles.Cramer (cramer) where
 
 import Control.Monad (forM_, replicateM_, unless, when)
-import Control.Monad.State.Strict (MonadState, get, gets, put)
+import Control.Monad.State.Strict (get, gets, put)
 
 import Data.List (intersperse, sortOn)
 import Data.Maybe (catMaybes, isJust, mapMaybe)
@@ -159,33 +159,27 @@ lineDelta prev next = nextLine - prevLine
         annComment (Comment _ sp _) = sp
 
 -- | Specialized forM_ for Maybe.
-maybeM_ :: Monad m
-        => Maybe a -> (a -> m ()) -> m ()
+maybeM_ :: Maybe a -> (a -> Printer s ()) -> Printer s ()
 maybeM_ = forM_
 
 -- | Simplified HIndent.Pretty.inter that does not modify the indent level.
-inter :: MonadState (PrintState s) m
-      => m () -> [m ()] -> m ()
+inter :: Printer s () -> [Printer s ()] -> Printer s ()
 inter sep = sequence_ . intersperse sep
 
 -- | Simplified HIndent.Pretty.spaced that does not modify the indent level.
-spaced :: MonadState (PrintState s) m
-       => [m ()] -> m ()
+spaced :: [Printer s ()] -> Printer s ()
 spaced = inter space
 
 -- | Indent one level.
-indentFull :: MonadState (PrintState s) m
-           => m a -> m a
+indentFull :: Printer s a -> Printer s a
 indentFull p = getIndentSpaces >>= flip indented p
 
 -- | Indent a half level.
-indentHalf :: MonadState (PrintState s) m
-           => m a -> m a
+indentHalf :: Printer s a -> Printer s a
 indentHalf p = getIndentSpaces >>= flip indented p . (`div` 2)
 
 -- | Set indentation level to current column.
-align :: MonadState (PrintState s) m
-      => m a -> m a
+align :: Printer s a -> Printer s a
 align p =
   do st <- get
      let col =
@@ -388,8 +382,7 @@ guardedRhsExpr (GuardedRhs _ guards expr) =
      rhsExpr expr
 
 -- | Pretty print a name for being an infix operator.
-prettyInfixOp :: MonadState (PrintState s) m
-              => QName NodeInfo -> m ()
+prettyInfixOp :: QName NodeInfo -> Printer s ()
 prettyInfixOp op =
   case op of
     Qual{} ->

--- a/src/HIndent/Styles/Fundamental.hs
+++ b/src/HIndent/Styles/Fundamental.hs
@@ -22,4 +22,5 @@ fundamental =
         ,styleInitialState = State
         ,styleExtenders = []
         ,styleDefConfig = def
-        ,styleCommentPreprocessor = return}
+        ,styleCommentPreprocessor = return
+        ,styleLinePenalty = defaultLinePenalty}

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -70,7 +70,7 @@ commentContent (Comment _ _ content) = content
 commentSrcSpan :: Comment -> SrcSpan
 commentSrcSpan (Comment _ srcSpan _) = srcSpan
 
-commentPreprocessor :: MonadState (PrintState s) m => [Comment] -> m [Comment]
+commentPreprocessor :: [Comment] -> Printer s [Comment]
 commentPreprocessor cs = do
   config <- gets psConfig
   col <- getColumn
@@ -777,7 +777,7 @@ writeCaseAlts alts = do
         newline
         indented indentSpaces $ depend (write "where ") (pretty binds)
 
-prettyCommentCallbacks :: (Pretty ast,MonadState (PrintState s) m) => ast NodeInfo -> (ComInfoLocation -> m ()) -> m ()
+prettyCommentCallbacks :: Pretty ast => ast NodeInfo -> (ComInfoLocation -> Printer s ()) -> Printer s ()
 prettyCommentCallbacks a f =
   do st <- get
      case st of

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -58,6 +58,7 @@ gibiansky = Style { styleName = "gibiansky"
                                                    , configClearEmptyLines = True
                                                    }
                   , styleCommentPreprocessor = commentPreprocessor
+                  , styleLinePenalty = defaultLinePenalty
                   }
 
 -- Field accessor for Comment.

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -7,8 +7,6 @@ import           Data.Foldable
 -- import           Control.Applicative ((<$>))
 import           Data.Maybe
 import           Data.List (unfoldr, isPrefixOf)
-import           Control.Monad.Trans.Maybe
-import           Data.Functor.Identity
 import           Control.Monad.State.Strict hiding (state, State, forM_, sequence_)
 import           Data.Typeable
 
@@ -786,12 +784,7 @@ prettyCommentCallbacks a f =
            printComments Before a
            f Before
            depend
-             (case listToMaybe (mapMaybe (makePrinter s) es) of
-                Just (Printer m) ->
-                  modify (\s' ->
-                            fromMaybe s'
-                                      (runIdentity (runMaybeT (execStateT m s'))))
-                Nothing -> prettyNoExt a)
+             (fromMaybe (prettyNoExt a) $ listToMaybe (mapMaybe (makePrinter s) es))
              (f After >> printComments After a)
   where makePrinter _ (Extender f) =
           case cast a of

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -57,7 +57,8 @@ johanTibell =
         ,styleDefConfig =
            defaultConfig {configMaxColumns = 80
                          ,configIndentSpaces = 4}
-        ,styleCommentPreprocessor = return}
+        ,styleCommentPreprocessor = return
+        ,styleLinePenalty = defaultLinePenalty}
 
 --------------------------------------------------------------------------------
 -- Extenders

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -296,7 +296,7 @@ context (CxTuple _ asserts) =
   parens $ inter (comma >> space) $ map pretty asserts
 context ctx = prettyNoExt ctx
 
-unboxParens :: MonadState (PrintState s) m => m a -> m a
+unboxParens :: Printer s a -> Printer s a
 unboxParens p =
   depend (write "(# ")
          (do v <- p
@@ -448,14 +448,14 @@ isRecord (QualConDecl _ _ _ RecDecl{}) = True
 isRecord _ = False
 
 -- | Does printing the given thing overflow column limit? (e.g. 80)
-isOverflow :: MonadState (PrintState s) m => m a -> m Bool
+isOverflow :: Printer s a -> Printer s Bool
 isOverflow p =
   do (_,st) <- sandbox p
      columnLimit <- getColumnLimit
      return (psColumn st > columnLimit)
 
 -- | Does printing the given thing overflow column limit? (e.g. 80)
-fitsOnOneLine :: MonadState (PrintState s) m => m a -> m (Bool,PrintState s)
+fitsOnOneLine :: Printer s a -> Printer s (Bool,PrintState s)
 fitsOnOneLine p =
   do line <- gets psLine
      (_,st) <- sandbox p
@@ -463,8 +463,7 @@ fitsOnOneLine p =
      return (psLine st == line && psColumn st < columnLimit,st)
 
 -- | Is the given expression a single-liner when printed?
-isSingleLiner :: MonadState (PrintState s) m
-              => m a -> m Bool
+isSingleLiner :: Printer s a -> Printer s Bool
 isSingleLiner p =
   do line <- gets psLine
      (_,st) <- sandbox p
@@ -507,7 +506,7 @@ fieldupdate e =
                              pretty e'
     _ -> prettyNoExt e
 
-isSmall :: MonadState (PrintState t) m => m a -> m Bool
+isSmall :: Printer s a -> Printer s Bool
 isSmall p =
   do overflows <- isOverflow p
      oneLine <- isSingleLiner p

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -9,6 +9,7 @@
 
 module HIndent.Types
   (Printer(..)
+  ,execPrinter
   ,PrintState(..)
   ,Extender(..)
   ,Style(..)
@@ -21,7 +22,7 @@ module HIndent.Types
 
 import Control.Applicative
 import Control.Monad
-import Control.Monad.State.Strict (MonadState(..),StateT)
+import Control.Monad.State.Strict (MonadState(..),StateT,execStateT)
 import Control.Monad.Trans.Maybe
 import Data.Data
 import Data.Default
@@ -37,6 +38,9 @@ import Language.Haskell.Exts.SrcLoc
 newtype Printer s a =
   Printer {runPrinter :: StateT (PrintState s) (MaybeT Identity) a}
   deriving (Applicative,Monad,Functor,MonadState (PrintState s),MonadPlus,Alternative)
+
+execPrinter :: Printer s a -> PrintState s -> Maybe (PrintState s)
+execPrinter m s = runIdentity $ runMaybeT $ execStateT (runPrinter m) s
 
 -- | The state of the pretty printer.
 data PrintState s =

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -51,7 +51,7 @@ data PrintState s =
              ,psEolComment :: !Bool -- ^ An end of line comment has just been outputted.
              ,psInsideCase :: !Bool -- ^ Whether we're in a case statement, used for Rhs printing.
              ,psParseMode :: !ParseMode -- ^ Mode used to parse the original AST.
-             ,psCommentPreprocessor :: forall m. MonadState (PrintState s) m => [Comment] -> m [Comment] -- ^ Preprocessor applied to comments on an AST before printing.
+             ,psCommentPreprocessor :: forall t. [Comment] -> Printer t [Comment] -- ^ Preprocessor applied to comments on an AST before printing.
              }
 
 -- | A printer extender. Takes as argument the user state that the
@@ -69,7 +69,7 @@ data Style =
                   ,styleInitialState :: !s -- ^ User state, if needed.
                   ,styleExtenders :: ![Extender s] -- ^ Extenders to the printer.
                   ,styleDefConfig :: !Config -- ^ Default config to use for this style.
-                  ,styleCommentPreprocessor :: forall s' m. MonadState (PrintState s') m => [Comment] -> m [Comment] -- ^ Preprocessor to use for comments.
+                  ,styleCommentPreprocessor :: forall t. [Comment] -> Printer t [Comment] -- ^ Preprocessor to use for comments.
                   }
 
 -- | Configurations shared among the different styles. Styles may pay

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
 resolver: nightly-2015-12-11
 packages:
 - '.'
+extra-deps:
+- monad-dijkstra-0.1.0.0
+

--- a/test/cramer/expected/do.exp
+++ b/test/cramer/expected/do.exp
@@ -5,10 +5,8 @@ main = do
 main = repeatedly $ do
     getLine >>= putStrLn
 
-main = repeatedly $
-    getline >>=
-        \s -> do
-            putStrLn s
+main = repeatedly $ getline >>= \s -> do
+    putStrLn s
 
 main =
     -- comment

--- a/test/cramer/expected/lists.exp
+++ b/test/cramer/expected/lists.exp
@@ -8,12 +8,13 @@ short :: [Int]
 short = [ 1, 2, 3, 4, 5 ]
 
 lorem :: [String]
-lorem = [ "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        , "Curabitur nec ante nec mauris ornare suscipit."
-        , "In ac vulputate libero."
-        , "Duis eget magna non purus imperdiet molestie nec quis mauris."
-        , "Praesent blandit quam vel arcu pellentesque, id aliquet turpis faucibus."
-        ]
+lorem =
+    [ "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    , "Curabitur nec ante nec mauris ornare suscipit."
+    , "In ac vulputate libero."
+    , "Duis eget magna non purus imperdiet molestie nec quis mauris."
+    , "Praesent blandit quam vel arcu pellentesque, id aliquet turpis faucibus."
+    ]
 
 comment :: [Int]
 comment = [ 1 -- the first

--- a/test/cramer/expected/search.exp
+++ b/test/cramer/expected/search.exp
@@ -1,0 +1,50 @@
+runSearchT m = catMaybes <$> evalStateT go state
+  where
+    step num prio cand = do
+        case path' of
+            Free (Cost c e p) ->
+                let newCost = candCost `mappend` c
+                    newPriority = newCost `mappend` e
+                in do
+                    updateQueue $
+                        PSQ.insert num
+                                   newPriority
+                                   cand { candCost = newCost, candPath = p }
+                    return Nothing
+
+foo . bar . baz . quux . quuz . quuuuuz . lorem . ipsum .
+    dolor . sit . amet . consectetur . adipiscing . elit . sed . doo . eiusmod .
+        tempor . incididunt . ut . labore . et . dolore . magna . aliqua
+
+randomId = do
+    bytes <- replicateM 8 (randomIO :: IO Word8)
+    return $ concatMap (\n -> map (intToDigit . fromIntegral)
+                                  [ (n `shiftR` 4) .&. 0x0f
+                                  , (n `shiftR` 0) .&. 0x0f
+                                  ])
+                       bytes
+
+data DocumentType =
+    DocumentType { docId                 :: Maybe Word32
+                 , docDoctype            :: Maybe Text
+                 , docElements           :: Map.Map CodepageReference Text
+                 , docAttributeStarts    :: Map.Map CodepageReference ( Text
+                                                                      , Text
+                                                                      )
+                 , docAttributeValues    :: Map.Map CodepageReference Text
+                 , docRevElements        :: Map.Map ByteString CodepageReference
+                 , docRevAttributeStarts :: Trie.Trie CodepageReference
+                 , docRevAttributeValues :: Trie.Trie CodepageReference
+                 }
+
+instance Serial m a => Serial m (AuthenticatedData a) where
+    series =
+        AuthenticatedData <$> pure example
+                          <~> elements [ Nothing, Just example ]
+                          <~> elements [ [], [ example ] ]
+                          <~> pure example
+                          <~> elements [ Nothing, Just example ]
+                          <~> series
+                          <~> elements [ Nothing, Just [], Just [ example ] ]
+                          <~> pure example
+                          <~> elements [ Nothing, Just [], Just [ example ] ]

--- a/test/cramer/expected/typesig.exp
+++ b/test/cramer/expected/typesig.exp
@@ -11,6 +11,14 @@ long :: (IsString a, Monad m)
      -> a
      -> m ()
 
+mkEncoderData :: DocumentType
+              -> (Text -> Except String ByteString)
+              -> EncoderData
+
+codepageReference :: (ParserState -> Word8)
+                  -> AP.Parser Word8
+                  -> Parser CodepageReference
+
 mktime :: Int -- hours
        -> Int -- minutes
        -> Int -- seconds

--- a/test/cramer/tests/search.test
+++ b/test/cramer/tests/search.test
@@ -1,0 +1,29 @@
+runSearchT m = catMaybes <$> evalStateT go state
+  where
+    step num prio cand = do
+        case path' of
+            Free (Cost c e p) ->
+                let newCost = candCost `mappend` c
+                    newPriority = newCost `mappend` e
+                in do
+                    updateQueue $ PSQ.insert num newPriority cand { candCost = newCost, candPath = p }
+                    return Nothing
+
+foo . bar . baz . quux . quuz . quuuuuz . lorem . ipsum . dolor . sit . amet . consectetur . adipiscing . elit . sed . doo . eiusmod . tempor . incididunt . ut . labore . et . dolore . magna . aliqua
+
+randomId = do
+    bytes <- replicateM 8 (randomIO :: IO Word8)
+    return $ concatMap (\n -> map (intToDigit . fromIntegral) [ (n `shiftR` 4) .&. 0x0f, (n `shiftR` 0) .&. 0x0f ]) bytes
+
+data DocumentType = DocumentType { docId                 :: Maybe Word32
+                                 , docDoctype            :: Maybe Text
+                                 , docElements           :: Map.Map CodepageReference Text
+                                 , docAttributeStarts    :: Map.Map CodepageReference ( Text, Text )
+                                 , docAttributeValues    :: Map.Map CodepageReference Text
+                                 , docRevElements        :: Map.Map ByteString CodepageReference
+                                 , docRevAttributeStarts :: Trie.Trie CodepageReference
+                                 , docRevAttributeValues :: Trie.Trie CodepageReference
+                                 }
+
+instance Serial m a => Serial m (AuthenticatedData a) where
+    series = AuthenticatedData <$> pure example <~> elements [ Nothing, Just example ] <~> elements [ [], [ example ] ] <~> pure example <~> elements [ Nothing, Just example ] <~> series <~> elements [ Nothing, Just [], Just [ example ] ] <~> pure example <~> elements [ Nothing, Just [], Just [ example ] ]

--- a/test/cramer/tests/typesig.test
+++ b/test/cramer/tests/typesig.test
@@ -4,6 +4,10 @@ sort :: Ord a => [a] -> [a]
 
 long :: (IsString a, Monad m) => ByteString -> ByteString -> ByteString -> ByteString -> ByteString -> a -> m ()
 
+mkEncoderData :: DocumentType -> (Text -> Except String ByteString) -> EncoderData
+
+codepageReference :: (ParserState -> Word8) -> AP.Parser Word8 -> Parser CodepageReference
+
 mktime :: Int -- hours
        -> Int -- minutes
        -> Int -- seconds


### PR DESCRIPTION
This pull request augments the pretty printing framework for flexible, non-deterministic printing based on alternatives and penalties.

With these changes, instead of manually inspecting the result of certain formatting choices (e.g. single-line vs multi-line formatting), styles can simply list different formatting options using the `MonadPlus` type class. Each alternative branch and each line generated can be associated with a penalty. The printing framework will select the combination of options resulting in the minimal overall penalty.

The default settings simply penalises line breaks and overfull lines, thus trying to produce as few lines as possible without overflowing the right column limit.

Behavior of styles that do not explicitly use the newly provided functionality remains unchanged.

See style "Cramer" for an example on how the functionality is used.