### PR TITLE
Include benchmarks/BigDeclarations.hs in extra-source-files

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -17,6 +17,7 @@ homepage: http://www.github.com/chrisdone/hindent
 bug-reports: https://github.com/chrisdone/hindent/issues
 data-files:          elisp/hindent.el vim/hindent.vim
 extra-source-files:  README.md
+                     benchmarks/BigDeclarations.hs
                      test/chris-done/expected/*.exp
                      test/chris-done/tests/*.test
                      test/gibiansky/expected/*.exp


### PR DESCRIPTION
Without it, `cabal sdist` won't include the file in the tarball on Hackage, which means that the benchmarks will fail to run:

```
Benchmark hindent-bench: RUNNING...
hindent-bench: benchmarks/BigDeclarations.hs: openFile: does not exist (No such file or directory)
Benchmark hindent-bench: ERROR
```

See also https://github.com/iu-parfunc/sc-haskell/issues/7