### PR TITLE
remove data-default dependency

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -44,7 +44,6 @@ library
                      HIndent.Styles.Cramer
   build-depends:     base >= 4.7 && <5
                    , containers
-                   , data-default
                    , haskell-src-exts >= 1.17
                    , monad-loops
                    , mtl
@@ -78,7 +77,6 @@ test-suite hspec
   main-is: Spec.hs
   build-depends:     base >= 4 && <5
                    , hindent
-                   , data-default
                    , haskell-src-exts
                    , monad-loops
                    , mtl

--- a/src/HIndent/Styles/Fundamental.hs
+++ b/src/HIndent/Styles/Fundamental.hs
@@ -7,8 +7,6 @@ module HIndent.Styles.Fundamental where
 
 import HIndent.Types
 
-import Data.Default
-
 
 -- | Empty state.
 data State = State
@@ -21,5 +19,5 @@ fundamental =
         ,styleDescription = "This style adds no extensions to the built-in printer."
         ,styleInitialState = State
         ,styleExtenders = []
-        ,styleDefConfig = def
+        ,styleDefConfig = defaultConfig
         ,styleCommentPreprocessor = return}

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -24,7 +24,6 @@ import Control.Monad
 import Control.Monad.State.Strict (MonadState(..),StateT)
 import Control.Monad.Trans.Maybe
 import Data.Data
-import Data.Default
 import Data.Functor.Identity
 import Data.Int (Int64)
 import Data.Text (Text)
@@ -80,15 +79,12 @@ data Config =
          ,configClearEmptyLines :: !Bool  -- ^ Remove spaces on lines that are otherwise empty?
          }
 
-instance Default Config where
-  def =
-    Config {configMaxColumns = 80
-           ,configIndentSpaces = 2
-           ,configClearEmptyLines = False}
-
 -- | Default style configuration.
 defaultConfig :: Config
-defaultConfig = def
+defaultConfig =
+  Config {configMaxColumns = 80
+         ,configIndentSpaces = 2
+         ,configClearEmptyLines = False}
 
 -- | Information for each node in the AST.
 data NodeInfo =


### PR DESCRIPTION
`data-default` pulls in a bunch of unneeded packages because it provides instances for them. That could have also been remedied by using `data-default-class` instead. But since it's actual use is marginal I figured it could go altogether.