### PR TITLE
Update to haskell-src-exts 1.18

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -45,7 +45,7 @@ library
                      HIndent.Styles.Cramer
   build-depends:     base >= 4.7 && <5
                    , containers
-                   , haskell-src-exts >= 1.17
+                   , haskell-src-exts >= 1.18
                    , monad-loops
                    , mtl
                    , text

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -49,7 +49,7 @@ import qualified Data.Text.Lazy as T hiding (singleton)
 import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as T
 import qualified Data.Text.Lazy.IO as T
-import           Language.Haskell.Exts.Annotated hiding (Style, prettyPrint, Pretty, style, parse)
+import           Language.Haskell.Exts hiding (Style, prettyPrint, Pretty, style, parse)
 
 data CodeBlock = HaskellSource Text
                | CPPDirectives Text

--- a/src/HIndent/Comments.hs
+++ b/src/HIndent/Comments.hs
@@ -12,7 +12,7 @@ import Data.Data
 import qualified Data.Map.Strict as M
 import Data.Traversable
 import HIndent.Types
-import Language.Haskell.Exts.Annotated hiding (Style,prettyPrint,Pretty,style,parse)
+import Language.Haskell.Exts hiding (Style,prettyPrint,Pretty,style,parse)
 
 -- Order by start of span, larger spans before smaller spans.
 newtype OrderByStart =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -70,6 +70,7 @@ import           Control.Monad.State.Strict hiding (state)
 import           Data.Int
 import           Data.List
 import           Data.Maybe
+import           Data.Foldable (traverse_)
 import           Data.Monoid hiding (Alt)
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -78,8 +79,8 @@ import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as T
 import           Data.Text.Lazy.Builder.Int
 import           Data.Typeable
-import qualified Language.Haskell.Exts.Annotated as P
-import           Language.Haskell.Exts.Annotated.Syntax
+import qualified Language.Haskell.Exts as P
+import           Language.Haskell.Exts.Syntax
 import           Language.Haskell.Exts.SrcLoc
 import           Prelude hiding (exp)
 
@@ -571,8 +572,9 @@ instance Pretty Type where
         parens (do pretty ty
                    write " :: "
                    pretty k)
-      TyBang _ bangty right ->
-        do pretty bangty
+      TyBang _ bangty unpackty right ->
+        do pretty unpackty
+           pretty bangty
            pretty right
       TyEquals _ left right ->
         do pretty left
@@ -934,7 +936,13 @@ instance Pretty BangType where
   prettyInternal x =
     case x of
       BangedTy _ -> write "!"
-      UnpackedTy _ -> write "{-# UNPACK #-} !"
+      LazyTy _ -> write "~"
+      NoStrictAnnot _ -> pure ()
+
+instance Pretty Unpackedness where
+  prettyInternal (Unpack _) = write "{-# UNPACK -#}"
+  prettyInternal (NoUnpack _) = write "{-# NOUNPACK -#}"
+  prettyInternal (NoUnpackPragma _) = pure ()
 
 instance Pretty Binds where
   prettyInternal x =
@@ -955,15 +963,12 @@ instance Pretty ClassDecl where
                                Just kind ->
                                  do write " :: "
                                     pretty kind)))
-      ClsTyFam _ h mkind ->
+      ClsTyFam _ h mkind minj ->
         depend (write "type ")
                (depend (pretty h)
-                       (case mkind of
-                          Nothing -> return ()
-                          Just kind ->
-                            do write " :: "
-                               pretty kind))
-      ClsTyDef _ this that ->
+                       (depend (traverse_ (\kind -> write " :: " >> pretty kind) mkind)
+                               (traverse_ pretty minj)))
+      ClsTyDef _ (TypeEqn _ this that) ->
         do write "type "
            pretty this
            write " = "
@@ -1020,6 +1025,9 @@ instance Pretty GuardedRhs where
                                stmts))
            swing (write " " >> rhsSeparator >> write " ")
                  (pretty e)
+
+instance Pretty InjectivityInfo where
+  prettyInternal x = pretty' x
 
 instance Pretty InstDecl where
   prettyInternal i =
@@ -1245,6 +1253,10 @@ instance Pretty FunDep where
 instance Pretty Kind where
   prettyInternal = pretty'
 
+instance Pretty ResultSig where
+  prettyInternal (KindSig _ kind) = pretty kind
+  prettyInternal (TyVarSig _ tyVarBind) = pretty tyVarBind
+
 instance Pretty Literal where
   prettyInternal (String _ _ rep) = do
     write "\""
@@ -1313,7 +1325,10 @@ instance Pretty ImportSpec where
   prettyInternal = pretty'
 
 instance Pretty WarningText where
-  prettyInternal = pretty'
+  prettyInternal (DeprText _ s) =
+    write "{-# DEPRECATED " >> string s >> write " #-}"
+  prettyInternal (WarnText _ s) =
+    write "{-# WARNING " >> string s >> write " #-}"
 
 instance Pretty ExportSpecList where
   prettyInternal (ExportSpecList _ es) =

--- a/src/HIndent/Styles/ChrisDone.hs
+++ b/src/HIndent/Styles/ChrisDone.hs
@@ -16,9 +16,9 @@ import Control.Monad.Loops
 import Control.Monad.State.Class
 import Data.Int
 import Data.Maybe
-import Language.Haskell.Exts.Annotated (parseExpWithComments)
-import Language.Haskell.Exts.Annotated.Fixity
-import Language.Haskell.Exts.Annotated.Syntax
+import Language.Haskell.Exts (parseExpWithComments)
+import Language.Haskell.Exts.Fixity
+import Language.Haskell.Exts.Syntax
 import Language.Haskell.Exts.Parser (ParseResult(..))
 import Prelude hiding (exp)
 import Data.Monoid

--- a/src/HIndent/Styles/Cramer.hs
+++ b/src/HIndent/Styles/Cramer.hs
@@ -12,7 +12,7 @@ import Control.Monad.State.Strict (MonadState, get, gets, put)
 import Data.List (intersperse, sortOn)
 import Data.Maybe (catMaybes, isJust, mapMaybe)
 
-import Language.Haskell.Exts.Annotated.Syntax
+import Language.Haskell.Exts.Syntax
 import Language.Haskell.Exts.Comments
 import Language.Haskell.Exts.SrcLoc
 import Language.Haskell.Exts (prettyPrint)

--- a/src/HIndent/Styles/Gibiansky.hs
+++ b/src/HIndent/Styles/Gibiansky.hs
@@ -15,7 +15,7 @@ import           Data.Typeable
 import           HIndent.Pretty
 import           HIndent.Types
 
-import           Language.Haskell.Exts.Annotated.Syntax
+import           Language.Haskell.Exts.Syntax
 import           Language.Haskell.Exts.SrcLoc
 import           Language.Haskell.Exts.Pretty (prettyPrint)
 import           Language.Haskell.Exts.Comments

--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -21,7 +21,7 @@ import Data.Maybe
 import HIndent.Pretty
 import HIndent.Styles.ChrisDone (infixApp)
 import HIndent.Types
-import Language.Haskell.Exts.Annotated.Syntax
+import Language.Haskell.Exts.Syntax
 import Prelude hiding (exp)
 
 --------------------------------------------------------------------------------

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -21,7 +21,7 @@ import           Data.Version (showVersion)
 import           Descriptive
 import           Descriptive.Options
 import           GHC.Tuple
-import           Language.Haskell.Exts.Annotated hiding (Style,style)
+import           Language.Haskell.Exts hiding (Style,style)
 import           Paths_hindent (version)
 import           System.Directory
 import           System.Environment

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
-resolver: lts-5.13
+resolver: lts-6.10
 packages:
 - '.'
+extra-deps:
+- haskell-src-exts-1.18.2


### PR DESCRIPTION
Probably supersedes #149.

I didn’t add support for any new features, but the tests pass and some passing errors that I was experiencing seem to be fixed so imho it’s still a worthwhile upgrade.