### PR TITLE
Fix printing of qualified infix operators in patterns

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -522,7 +522,10 @@ instance Pretty Pat where
 prettyInfixOp :: MonadState (PrintState s) m => QName NodeInfo -> m ()
 prettyInfixOp x =
   case x of
-    Qual{} -> do write "`"; pretty' x; write "`"
+    Qual _ mn n ->
+      case n of
+        Ident _ i -> do write "`"; pretty mn; write "."; string i; write "`";
+        Symbol _ s -> do pretty mn; write "."; string s;
     UnQual _ n ->
       case n of
         Ident _ i -> string ("`" ++ i ++ "`")


### PR DESCRIPTION
Formerly parentheses as well as backticks were added, which is a parse error for GHC.