### PR TITLE
Improve indentation for patterns

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -484,8 +484,12 @@ instance Pretty Pat where
         brackets (commas (map pretty ps))
       PParen _ e -> parens (pretty e)
       PRec _ qname fields ->
-        depend (pretty qname)
-               (braces (commas (map pretty fields)))
+        do indentSpaces <- getIndentSpaces
+           depend (do pretty qname
+                      space)
+                  (braces (prefixedLined ","
+                                         (map (indented indentSpaces . pretty) fields)))
+
       PAsPat _ n p ->
         depend (do pretty n
                    write "@")


### PR DESCRIPTION
Currently patterns don't get any special treatment by the ChrisDone style. Usually I try to avoid lengthy pattern matches and long argument lists. Still, it would be nice if the style had a better answer than putting everything on one line. Since patterns can be treated very similar to expressions this PR pretty much just clones the handling for expressions and adapts it to patterns. I think this is a useful baseline.

That has some unfortunate consequences like `f (x:xs) (y:ys)` getting split over two lines, just like the corresponding expression. This particular case could be fixed, for example, by increasing the notion of flatish(ness) for patterns to two non-flat elements, but that seems rather ad-hoc and indicates to me that the line breaking logic could be tweaked a little in general (`f (x:xs) (y:ys)` as an expression shouldn't be split over two lines either).

This is increasingly a matter of opinion of course (maybe you want that expression split up). So this is my personal take. As an experiment I removed the flatness and short head heuristic so that everything is put on a single line if it doesn't overflow. That wasn't too bad, it fixed some over-eager line breaking, but at other points readability suffered. I actually like not having to scan a whole line for matching parentheses. I think a heuristic whether to split an expression (or pattern) which is below the maximum column bound, that could work for me, would be to put every argument on it's own line if the length of any argument exceeds something around 10 to 15 characters (without parentheses) printed.

Anyway, this is of course a rather specific idea and this is you personal style, so what's your take on this? More specifically how do you want to handle patterns ideally?