### PR TITLE
Fix Travis build

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -947,12 +947,12 @@ instance Pretty BangType where
     case x of
       BangedTy _ -> write "!"
       LazyTy _ -> write "~"
-      NoStrictAnnot _ -> pure ()
+      NoStrictAnnot _ -> return ()
 
 instance Pretty Unpackedness where
   prettyInternal (Unpack _) = write "{-# UNPACK -#}"
   prettyInternal (NoUnpack _) = write "{-# NOUNPACK -#}"
-  prettyInternal (NoUnpackPragma _) = pure ()
+  prettyInternal (NoUnpackPragma _) = return ()
 
 instance Pretty Binds where
   prettyInternal x =

--- a/src/main/Benchmark.hs
+++ b/src/main/Benchmark.hs
@@ -19,12 +19,10 @@ main =
     [env setupEnv
          (\ ~bigDecls ->
              bgroup "Main"
-                    [bgroup "BigDeclarations"
-                            [bench ("HIndent.reformat: " ++
-                                    show (styleName style))
+                    [bench "HIndent.reformat big declarations: "
                                    (nf (either error T.toLazyText .
-                                        reformat style (Just defaultExtensions))
-                                       bigDecls)|style <- styles]])]
+                                        reformat johanTibell (Just defaultExtensions))
+                                       bigDecls)])]
 
 -- | Setup the environment for the benchmarks.
 setupEnv :: IO Text


### PR DESCRIPTION
The recent migration to a single style broke the Travis CI build. 

This PR is a newcomer's attempt to fix the build by updating the big declarations benchmark to only test the `johanTibell` style.

And also, updates `Pretty` to use `return` instead of `pure`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chrisdone/hindent/213)
<!-- Reviewable:end -->
