### PR TITLE
WIP: Use mapM_ instead of traverse_ for 7.8 compat

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -972,11 +972,11 @@ instance Pretty ClassDecl where
                                Just kind ->
                                  do write " :: "
                                     pretty kind)))
-      ClsTyFam _ h mkind minj ->
+      ClsTyFam _ h bindings mkind ->
         depend (write "type ")
                (depend (pretty h)
                        (depend (mapM_ (\kind -> write " :: " >> pretty kind) mkind)
-                               (mapM_ pretty minj)))
+                               (mapM_ pretty bindings)))
       ClsTyDef _ (TypeEqn _ this that) ->
         do write "type "
            pretty this

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -71,7 +71,6 @@ import           Control.Monad.State.Strict hiding (state)
 import           Data.Int
 import           Data.List
 import           Data.Maybe
-import           Data.Foldable (traverse_)
 import           Data.Monoid hiding (Alt)
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -976,8 +975,8 @@ instance Pretty ClassDecl where
       ClsTyFam _ h mkind minj ->
         depend (write "type ")
                (depend (pretty h)
-                       (depend (traverse_ (\kind -> write " :: " >> pretty kind) mkind)
-                               (traverse_ pretty minj)))
+                       (depend (mapM_ (\kind -> write " :: " >> pretty kind) mkind)
+                               (mapM_ pretty minj)))
       ClsTyDef _ (TypeEqn _ this that) ->
         do write "type "
            pretty this


### PR DESCRIPTION
https://github.com/commercialhaskell/stack/issues/563 and https://github.com/haskell/cabal/issues/2653 make it difficult for me to build locally with ghc 7.8, so I missed this one.

In case you are wondering, I don't care that much about GHC 7.8 but I do like green builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chrisdone/hindent/214)
<!-- Reviewable:end -->
