### PR TITLE
Fix spacing of module exports

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -19,10 +19,10 @@ Exports
 
 ``` haskell
 module X
-  (x
-  ,y
-  ,Z
-  ,P(x, z))
+  ( x
+  , y
+  , Z
+  , P(x, z))
   where
 ```
 

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1266,7 +1266,7 @@ instance Pretty ExportSpecList where
                           (map pretty es))
 
 instance Pretty ExportSpec where
-  prettyInternal = pretty'
+  prettyInternal x = string " " >> pretty' x
 
 -- Do statements need to handle infix expression indentation specially because
 -- do x *


### PR DESCRIPTION
This fixes part of #206.

I can't figure out how to get the closing parenthesis on the same like as the `where` with correct spacing. 