### PR TITLE
Fix two bugs about formatting comments

### DIFF
--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -175,7 +175,7 @@ prettyPrint config mode' m comments =
                -- For the time being, assume that all "free-floating" comments come at the beginning.
                -- If they were not at the beginning, they would be after some ast node.
                -- Thus, print them before going for the ast.
-               (do mapM_ (printComment Nothing) csComments
+               (do mapM_ (printComment Nothing) (reverse csComments)
                    pretty ast))
 
 -- | Pretty print the given printable thing.

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -306,6 +306,7 @@ write x =
   do eol <- gets psEolComment
      hardFail <- gets psHardLimit
      let addingNewline = eol && x /= "\n"
+     when addingNewline newline
      state <- get
      when
        hardFail
@@ -313,7 +314,6 @@ write x =
           (not addingNewline &&
            additionalLines == 0 &&
            (psColumn state < configMaxColumns (psConfig state))))
-     when addingNewline newline
      let clearEmpty =
            configClearEmptyLines (psConfig state)
          writingNewline = x == "\n"


### PR DESCRIPTION
I have fixed two bugs about formatting comments.

1. No newline token between different lines.
2. The multi-line leading comments are formatted in reverse order, this bug was introduced in the commmit [e7e7168fc4427566503396551a2331e4b0d3d74d]. This bug also can be reproduced using hindent-5.0.1.

A simple test case that can be used to reproduce these two bugs is as follow:

~~~haskell
-- | Module xxxx
--
-- YYYY
-- xxxxx

import XXX.XXX

-- aaaa
-- bbbb
~~~

When use hindent-5.0.1, the result is:

~~~haskell
-- xxxxx
-- YYYY
--
-- | Module xxxx
import XXX.XXX-- aaaa
              -- bbbb
              -- cccc
~~~

When use hindent-master, the result is:

~~~haskell
-- xxxxx-- YYYY---- | Module xxxximport XXX.XXX-- aaaa-- bbbb-- cccc
~~~
