### PR TITLE
Fix two bugs about pragmas.

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -825,8 +825,8 @@ instance Pretty BangType where
       NoStrictAnnot _ -> return ()
 
 instance Pretty Unpackedness where
-  prettyInternal (Unpack _) = write "{-# UNPACK -#}"
-  prettyInternal (NoUnpack _) = write "{-# NOUNPACK -#}"
+  prettyInternal (Unpack _) = write "{-# UNPACK #-}"
+  prettyInternal (NoUnpack _) = write "{-# NOUNPACK #-}"
   prettyInternal (NoUnpackPragma _) = return ()
 
 instance Pretty Binds where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -763,11 +763,15 @@ decl (DataDecl _ dataornew ctx dhead condecls mderivs) =
                             (prefixedLined "|"
                                            (map (depend space . pretty) xs)))
 
-decl (InlineSig _ inline _ name) = do
+decl (InlineSig _ inline active name) = do
   write "{-# "
 
   unless inline $ write "NO"
   write "INLINE "
+  case active of
+    Nothing -> return ()
+    Just (ActiveFrom _ x) -> write ("[" ++ show x ++ "] ")
+    Just (ActiveUntil _ x) -> write ("[~" ++ show x ++ "] ")
   pretty name
 
   write " #-}"


### PR DESCRIPTION
Fix two bugs about pragma declarations. One is a typo in `UNPACK/UNPACK` handler, another is about activation clause of INLINE/NOINLINE pragmas.

A simple example that can be used to reproduce them:

~~~haskell
data A = A { a :: {-# UNPACK #-} !Int}

f :: Int
f = undefined

{-# INLINE [1] f #-}
~~~