### PR TITLE
Put last paren of export list on a new line

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -24,8 +24,8 @@ module X
   ( x
   , y
   , Z
-  , P(x, z))
-  where
+  , P(x, z)
+  ) where
 ```
 
 ## Imports

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1182,9 +1182,7 @@ instance Pretty ModuleHead where
        maybe (return ())
              (\exports ->
                 do newline
-                   indented 2 (pretty exports)
-                   newline
-                   space)
+                   indented 2 (pretty exports))
              mexports
        write " where"
 
@@ -1211,9 +1209,11 @@ instance Pretty WarningText where
     write "{-# WARNING " >> string s >> write " #-}"
 
 instance Pretty ExportSpecList where
-  prettyInternal (ExportSpecList _ es) =
-    parens (prefixedLined ","
-                          (map pretty es))
+  prettyInternal (ExportSpecList _ es) = do
+    depend (write "(")
+           (prefixedLined "," (map pretty es))
+    newline
+    write ")"
 
 instance Pretty ExportSpec where
   prettyInternal x = string " " >> pretty' x


### PR DESCRIPTION
Addresses #206, this changes:

```haskell
 module A
    ( b
    , c)
    where
```
to:
```haskell
module A
    ( b
    , c
    ) where
```