### PR TITLE
Fixed issue #255 (no newlines after top-level pragma)

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -607,6 +607,15 @@ data Simple =
   deriving (Show)
 ```
 
+sgraf812 top-level pragmas should not add an additional newline #255
+
+``` haskell
+-- https://github.com/chrisdone/hindent/issues/255
+{-# INLINE f #-}
+f :: Int -> Int
+f n = n
+```
+
 # Behaviour checks
 
 Unicode

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1057,6 +1057,7 @@ instance Pretty Module where
                             ,interOf newline
                                      (map (\case
                                              r@TypeSig{} -> (1,pretty r)
+                                             r@InlineSig{} -> (1, pretty r)
                                              r -> (2,pretty r))
                                           decls))])
            newline


### PR DESCRIPTION
For the record, I'm summing up what I said in the issue discussion:

> Implementing the first version (pragmas before decl) was trivial, however the second (pragmas after decl) wouldn't be so easy, because individual decls can only add newlines after them. I prefer the first version anyway (feels like a type signature), but the second is suggested by the style guide.

I could just add the cases for RULE, DEPRECATED, WARNING, SPECIALISE, ANN, MINIMAL, while I'm at it.
