### PR TITLE
add test "Long arguments list" to uncover inconsistency

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -153,6 +153,13 @@ x =
 
 # Type signatures
 
+Long arguments list
+
+```haskell
+longLongFunction :: ReaderT r (WriterT w (StateT s m)) a
+                 -> StateT s (WriterT w (ReaderT r m)) a
+```
+
 Class constraints
 
 ``` haskell


### PR DESCRIPTION
Compare:

Long arguments list

```haskell
longLongFunction :: ReaderT r (WriterT w (StateT s m)) a
                 -> StateT s (WriterT w (ReaderT r m)) a
```

Class constraints

```haskell
fun
  :: (Class a, Class b)
  => a -> b -> c
```