### PR TITLE
Allow hindent.el to work with older hindent versions

### DIFF
--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -45,10 +45,13 @@
   nil
   "The style to use for formatting.
 
-This customization is deprecated and ignored."
+For hindent versions lower than 5, you must set this to a non-nil string."
   :group 'hindent
   :type 'string
   :safe #'stringp)
+
+(make-obsolete-variable 'hindent-style nil "hindent 5")
+
 
 (defcustom hindent-process-path
   "hindent"
@@ -305,9 +308,11 @@ expected to work."
 (defun hindent-extra-arguments ()
   "Pass in extra arguments, such as extensions and optionally
 other things later."
-  (if (boundp 'haskell-language-extensions)
-      haskell-language-extensions
-    '()))
+  (append
+   (when (boundp 'haskell-language-extensions)
+     haskell-language-extensions)
+   (when hindent-style
+     (list "--style" hindent-style))))
 
 (provide 'hindent)
 


### PR DESCRIPTION
For a little while still, thanks to the stackage LTS system, people such as myself will be using the recent (MELPA) `hindent.el` with an `hindent` older than v5. This change allows us to keep things running until we're all in the grand future of One Style To Rule Them All.

With this change, hindent-style continues to default to nil, but when it is set, it will be passed to hindent.

This allows the elisp to work with older hindent programs, and if there is a mismatch between the user's hindent program and local settings of hindent-style, they notice it and be able to resolve it.