### PR TITLE
Fix issue #277, issue #278 and remove extra space in class declaration.

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -755,6 +755,18 @@ f :: Int -> Int
 f n = n
 ```
 
+ivan-timokhin breaks code with type operators #277
+
+```haskell
+-- https://github.com/chrisdone/hindent/issues/277
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+type m ~> n = ()
+
+class (a :< b) c
+```
+
 # Behaviour checks
 
 Unicode

--- a/TESTS.md
+++ b/TESTS.md
@@ -260,7 +260,7 @@ Default signatures
 
 ```haskell
 -- https://github.com/chrisdone/hindent/issues/283
-class Foo a  where
+class Foo a where
   bar :: a -> a -> a
   default bar :: Monoid a =>
     a -> a -> a

--- a/TESTS.md
+++ b/TESTS.md
@@ -767,6 +767,15 @@ type m ~> n = ()
 class (a :< b) c
 ```
 
+ivan-timokhin variables swapped around in constraints #278
+
+```haskell
+-- https://github.com/chrisdone/hindent/issues/278
+data Link c1 c2 a c =
+  forall b. (c1 a b, c2 b c) =>
+            Link (Proxy b)
+```
+
 # Behaviour checks
 
 Unicode

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -748,8 +748,7 @@ decl (FunBind _ matches) =
 decl (ClassDecl _ ctx dhead fundeps decls) =
   do depend (write "class ")
             (withCtx ctx
-                     (depend (do pretty dhead
-                                 space)
+                     (depend (do pretty dhead)
                              (depend (unless (null fundeps)
                                              (do write " | "
                                                  commas (map pretty fundeps)))

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1039,9 +1039,12 @@ instance Pretty DeclHead where
       DHInfix _ var name ->
         do pretty var
            space
-           write "`"
-           pretty name
-           write "`"
+           case name of
+              Ident _ _ -> do
+                write "`"
+                pretty name
+                write "`"
+              Symbol _ s -> write s
       DHApp _ dhead var ->
         depend (pretty dhead)
                (do space

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -844,7 +844,7 @@ instance Pretty Asst where
            write " ~ "
            pretty b
       ParenA _ asst -> parens (pretty asst)
-      AppA _ name tys -> spaced (pretty name : map pretty tys)
+      AppA _ name tys -> spaced (pretty name : map pretty (reverse tys))
       WildCardA _ name ->
         case name of
           Nothing -> write "_"


### PR DESCRIPTION
+ Fix issue #277.
+ Fix issue #278.
+ Remove extra space in class declaration before the `where` keyword.