### PR TITLE
Change TypeSig printing for textmate compatability

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -239,8 +239,8 @@ fun ::
 Class constraints
 
 ``` haskell
-fun
-  :: (Class a, Class b)
+fun ::
+  (Class a, Class b)
   => a -> b -> c
 ```
 
@@ -638,18 +638,18 @@ x = do
 meditans hindent freezes when trying to format this code #222
 
 ``` haskell
-c
-  :: forall new.
-     ( Settable "pitch" Pitch (Map.AsMap (new Map.:\ "pitch")) new
-     , Default (Book' (Map.AsMap (new Map.:\ "pitch")))
-     )
+c ::
+  forall new.
+  ( Settable "pitch" Pitch (Map.AsMap (new Map.:\ "pitch")) new
+  , Default (Book' (Map.AsMap (new Map.:\ "pitch")))
+  )
   => Book' new
 c = set #pitch C (def :: Book' (Map.AsMap (new Map.:\ "pitch")))
 
-foo
-  :: ( Foooooooooooooooooooooooooooooooooooooooooo
-     , Foooooooooooooooooooooooooooooooooooooooooo
-     )
+foo ::
+  ( Foooooooooooooooooooooooooooooooooooooooooo
+  , Foooooooooooooooooooooooooooooooooooooooooo
+  )
   => A
 ```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -225,6 +225,12 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
+```haskell
+longLonglongFunction ::
+     T "alonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongliteral" a
+  -> T "alonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongliteral" a
+```
+
 Class constraints should leave :: on same line
 
 ``` haskell pending

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1497,11 +1497,10 @@ decl' (TypeSig _ names ty') =
                           (declTy ty')
        Nothing -> do inter (write ", ")
                            (map pretty names)
+                     write " ::"
                      newline
                      indentSpaces <- getIndentSpaces
-                     indented indentSpaces
-                              (depend (write ":: ")
-                                      (declTy ty'))
+                     indented indentSpaces (declTy ty')
 
   where declTy dty =
           case dty of
@@ -1518,9 +1517,8 @@ decl' (TypeSig _ names ty') =
                    Just ctx ->
                      do pretty ctx
                         newline
-                        indented (-3)
-                                 (depend (write "=> ")
-                                         (prettyTy ty))
+                        depend (write "=> ")
+                               (prettyTy ty)
             _ -> prettyTy dty
         collapseFaps (TyFun _ arg result) = arg : collapseFaps result
         collapseFaps e = [e]

--- a/test.hs
+++ b/test.hs
@@ -1,0 +1,4 @@
+openTextDocumentRequest
+  :: TextDocumentIdentifier
+  -> SentRequestWrapper "vsch/registerTextDocumentContentProvider" True TextDocumentIdentifier Void Void
+openTextDocumentRequest = SentRequestWrapper


### PR DESCRIPTION
This is a speculative pr that addresses #284.

The only changes should be in the case of type signatures with context.
The placement of the :: is moved to the previous line, where the identifiers are.
The first line of context is moved three characters to the left, where the :: used to be.

I understand you're planning to look at how type signatures are formatted. I'm submitting this PR in case you are inclined to merge it in the interim, feel free to reject it otherwise.