### PR TITLE
Fix the bug about extra parentheses around symbolic names (issue #273)

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -852,6 +852,18 @@ data Link c1 c2 a c =
             Link (Proxy b)
 ```
 
+ttuegel qualified infix sections get mangled #273
+
+```haskell
+-- https://github.com/chrisdone/hindent/issues/273
+import qualified Data.Vector as V
+
+main :: IO ()
+main = do
+  let _ = foldr1 V.++ [V.empty, V.empty]
+  pure ()
+```
+
 # Behaviour checks
 
 Unicode

--- a/TESTS.md
+++ b/TESTS.md
@@ -860,8 +860,16 @@ import qualified Data.Vector as V
 
 main :: IO ()
 main = do
-  let _ = foldr1 V.++ [V.empty, V.empty]
+  let _ = foldr1 (V.++) [V.empty, V.empty]
   pure ()
+
+-- more corner cases.
+xs = V.empty V.++ V.empty
+
+ys = (++) [] []
+
+cons :: V.Vector a -> V.Vector a -> V.Vector a
+cons = (V.++)
 ```
 
 # Behaviour checks

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1071,7 +1071,7 @@ instance Pretty DeclHead where
                 write "`"
                 pretty name
                 write "`"
-              Symbol _ s -> write s
+              Symbol _ _ -> pretty name
       DHApp _ dhead var ->
         depend (pretty dhead)
                (do space
@@ -1215,7 +1215,9 @@ instance Pretty Literal where
   prettyInternal x = pretty' x
 
 instance Pretty Name where
-  prettyInternal = pretty' -- Var
+  prettyInternal x = case x of
+                          Ident _ _ -> pretty' x -- Identifiers.
+                          Symbol _ s -> string s -- Symbols
 
 instance Pretty QName where
   prettyInternal =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -670,6 +670,8 @@ exp (MultiIf _ alts) =
 exp (Lit _ lit) = prettyInternal lit
 exp (Var _ q) = case q of
                   Special _ Cons{} -> parens (pretty q)
+                  Qual _ _ (Symbol _ _) -> parens (pretty q)
+                  UnQual _ (Symbol _ _) -> parens (pretty q)
                   _ -> pretty q
 exp (IPVar _ q) = pretty q
 exp (Con _ q) = case q of


### PR DESCRIPTION
Hindent use `prettyPrint` from the haskell-src-exts to pretty print a `Name`, see [L1217](https://github.com/chrisdone/hindent/blob/master/src/HIndent/Pretty.hs#L1217), but when print a symbolic name separately, extra parentheses will be added.

~~~haskell
 > prettyPrint $ Symbol undefined "++"
"(++)"
 > prettyPrint $ Symbol undefined "L.++"
"(L.++)"
~~~

But when pretty print a whole expression, it works as expected.

~~~haskell
 > prettyPrint $ Symbol undefined "xs ++ ys"
"xs ++ ys"
 > prettyPrint $ Symbol undefined "xs L.++ ys"
"xs (L.++) ys"
~~~

This patch fixes issue #273 and also part of issue #277 (it was fixed by f49fb09d). I'm not sure whether its a bug of haskell-src-exts, or just a feature.
