### PR TITLE
Reformat long deriving clauses similar to long constraints.

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -879,6 +879,23 @@ ivan-timokhin breaks operators type signatures #301
 (+) :: ()
 ```
 
+cdepillabout Long deriving clauses are not reformatted #289
+
+```haskell
+newtype Foo =
+  Foo Proxy
+  deriving ( Functor
+           , Applicative
+           , Monad
+           , Semigroup
+           , Monoid
+           , Alternative
+           , MonadPlus
+           , Foldable
+           , Traversable
+           )
+```
+
 # Behaviour checks
 
 Unicode


### PR DESCRIPTION
Reformat long deriving clauses.  This is similar to how long
function constraint lists are reformated over multiple lines.

The following data type definition,

```
newtype Foo =
  Foo Proxy
  deriving (Functor, Applicative, Monad, Semigroup, Monoid, Alternative, MonadPlus, Foldable, Traversable)
```

is turned into this:

```
newtype Foo =
  Foo Proxy
  deriving ( Functor
           , Applicative
           , Monad
           , Semigroup
           , Monoid
           , Alternative
           , MonadPlus
           , Foldable
           , Traversable
           )
```

Closes #289.