### PR TITLE
Fix compile error caused by #341

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1771,6 +1771,11 @@ ifFitsOnOneLineOrElse a b = do
       put stOrig
       b
 
+-- | If printer after fits, use it, else use it after newline
+ifFitsOnOneLineThenSpaceElseNewline :: Printer a -> Printer a
+ifFitsOnOneLineThenSpaceElseNewline p =
+  ifFitsOnOneLineOrElse (space >> p) (newline >> p)
+
 bindingGroup :: Binds NodeInfo -> Printer ()
 bindingGroup binds =
   do newline


### PR DESCRIPTION
PR #341 causes a compile error as specified in https://github.com/chrisdone/hindent/pull/341#issuecomment-255536963.  This commit adds in the missing `ifFitsOnOneLineThenSpaceElseNewline` function so that `hindent` can be built again.

@cblp Does this look correct?