### PR TITLE
Fix travis build on lts-5.18 (ghc-7.10.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ install:
   set -ex
   case "$BUILD" in
     stack)
+      stack --no-terminal --install-ghc $ARGS install hsc2hs
       stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
       ;;
     cabal)


### PR DESCRIPTION
The travis ci build of `hindent` on lts-5.18 (ghc-7.10.3) is failing because of hsc2hs not being available.

https://travis-ci.org/chrisdone/hindent/jobs/170031296#L415

This appears to be the same problem(?) as discussed in the following stack issue:

https://github.com/commercialhaskell/stack/issues/595

This commit modifies the `.travis.yml` file to make sure `hsc2hs` is installed before building `hindent`'s dependencies.