### PR TITLE
Fix missing parentheses in instance declaration of type operators.

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -967,6 +967,17 @@ newtype Foo =
            )
 ```
 
+ivan-timokhin Breaks instances with type operators #342
+
+```haskell
+-- https://github.com/chrisdone/hindent/issues/342
+instance Foo (->)
+
+instance Foo (^>)
+
+instance Foo (T.<^)
+```
+
 # Behaviour checks
 
 Unicode

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1554,16 +1554,20 @@ typ x = case x of
                 space
                 pretty a
           TyVar _ n -> pretty n
-          TyCon _ p -> case p of
-                            Qual _ _ name -> case name of
-                                                  Ident _ _ -> pretty p
-                                                  Symbol _ _ -> parens (pretty p)
-                            UnQual _ name -> case name of
-                                                  Ident _ _ -> pretty p
-                                                  Symbol _ _ -> parens (pretty p)
-                            Special _ con -> case con of
-                                                  FunCon _ -> parens (pretty p)
-                                                  _ -> pretty p
+          TyCon _ p ->
+            case p of
+              Qual _ _ name ->
+                case name of
+                  Ident _ _ -> pretty p
+                  Symbol _ _ -> parens (pretty p)
+              UnQual _ name ->
+                case name of
+                  Ident _ _ -> pretty p
+                  Symbol _ _ -> parens (pretty p)
+              Special _ con ->
+                case con of
+                  FunCon _ -> parens (pretty p)
+                  _ -> pretty p
           TyParen _ e -> parens (pretty e)
           TyInfix _ a op b ->
             depend (do pretty a

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1554,7 +1554,16 @@ typ x = case x of
                 space
                 pretty a
           TyVar _ n -> pretty n
-          TyCon _ p -> pretty p
+          TyCon _ p -> case p of
+                            Qual _ _ name -> case name of
+                                                  Ident _ _ -> pretty p
+                                                  Symbol _ _ -> parens (pretty p)
+                            UnQual _ name -> case name of
+                                                  Ident _ _ -> pretty p
+                                                  Symbol _ _ -> parens (pretty p)
+                            Special _ con -> case con of
+                                                  FunCon _ -> parens (pretty p)
+                                                  _ -> pretty p
           TyParen _ e -> parens (pretty e)
           TyInfix _ a op b ->
             depend (do pretty a


### PR DESCRIPTION
Fix #342.
