### PR TITLE
Fix grouping of shebang lines.

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -843,7 +843,15 @@ instance forall x. Show x =>
 
 tfausak support shebangs #208
 
-``` haskell
+``` haskell given
+#!/usr/bin/env stack
+-- stack runghc
+main =
+ pure ()
+-- https://github.com/chrisdone/hindent/issues/208
+```
+
+``` haskell expect
 #!/usr/bin/env stack
 -- stack runghc
 main = pure ()


### PR DESCRIPTION
For a script like:

```haskell
#!/usr/bin/env stack
-- stack runghc
f x = x
```

The current `cppSplitBlocks` produces a single `Shebang` `CodeBlock` with all of the lines in it which causes no formatting to be applied to the file.