### PR TITLE
Add a space before the first promoted item of a promoted list

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -385,6 +385,19 @@ f
   => Int
 ```
 
+Promoted list (issue #348)
+
+```haskell
+a :: A '[ 'True]
+a = undefined
+```
+
+Promoted list with a tuple (issue #348)
+```haskell
+a :: A '[ '(a, b, c, d)]
+a = undefined
+```
+
 # Function declarations
 
 Prefix notation for operators

--- a/TESTS.md
+++ b/TESTS.md
@@ -393,6 +393,7 @@ a = undefined
 ```
 
 Promoted list with a tuple (issue #348)
+
 ```haskell
 a :: A '[ '(a, b, c, d)]
 a = undefined

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1611,6 +1611,11 @@ typ x = case x of
             do pretty left
                write " ~ "
                pretty right
+          TyPromoted _ (PromotedList _ _ (first@(TyPromoted _ _) : rest)) ->
+            do wrap "'[" "]" $ do
+                 space
+                 pretty' first
+                 mapM_ pretty' rest
           ty@TyPromoted{} -> pretty' ty
           TySplice _ splice -> pretty splice
           TyWildCard _ name ->


### PR DESCRIPTION
To avoid producing unparseable code with '['.

Attempts to fix #348.