### PR TITLE
Fix formatting of do as a left-hand side of an infix operation

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -985,6 +985,15 @@ instance Foo (^>)
 instance Foo (T.<^)
 ```
 
+NorfairKing Do as left-hand side of an infix operation #296
+
+```haskell
+block =
+  do ds <- inBraces $ inWhiteSpace declarations
+     return $ Block ds
+     <?> "block"
+```
+
 # Behaviour checks
 
 Unicode

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1839,14 +1839,18 @@ infixApp e a op b indent =
         ]
     ver = do
       prettyWithIndent a
-      space
-      pretty op
+      beforeRhs <- case a of
+                     Do _ _ -> do
+                       indentSpaces <- getIndentSpaces
+                       column (fromMaybe 0 indent + indentSpaces + 3) (newline >> pretty op) -- 3 = "do "
+                       return space
+                     _ -> space >> pretty op >> return newline
       case b of
         Lambda{} -> space >> pretty b
         LCase{} -> space >> pretty b
         Do _ stmts -> swing (write " do") $ lined (map pretty stmts)
         _ -> do
-          newline
+          beforeRhs
           case indent of
             Nothing -> prettyWithIndent b
             Just col -> do


### PR DESCRIPTION
Hopefully addresses #296