### PR TITLE
Fix promoted types pretty printing.

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -75,6 +75,8 @@ type EventSource a = (AddHandler a, a -> IO ())
 Type declaration with infix promoted type constructor
 
 ```haskell
+fun1 :: Def ('[Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+
 fun2 :: Def ('[Ref s (Stored Uint32), IBool] ':-> IBool)
 ```
 
@@ -390,6 +392,10 @@ Promoted list (issue #348)
 ```haskell
 a :: A '[ 'True]
 a = undefined
+
+-- nested promoted list with multiple elements.
+b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
+b = undefined
 ```
 
 Promoted list with a tuple (issue #348)
@@ -397,6 +403,10 @@ Promoted list with a tuple (issue #348)
 ```haskell
 a :: A '[ '(a, b, c, d)]
 a = undefined
+
+-- nested promoted tuples.
+b :: A '[ '( 'True, 'False, '[], '( 'False, 'True))]
+b = undefined
 ```
 
 # Function declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -75,9 +75,11 @@ type EventSource a = (AddHandler a, a -> IO ())
 Type declaration with infix promoted type constructor
 
 ```haskell
-fun1 :: Def ('[Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+fun1 = undefined
 
-fun2 :: Def ('[Ref s (Stored Uint32), IBool] ':-> IBool)
+fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
+fun2 = undefined
 ```
 
 Instance declaration without decls
@@ -401,7 +403,7 @@ b = undefined
 Promoted list with a tuple (issue #348)
 
 ```haskell
-a :: A '[ '(a, b, c, d)]
+a :: A '[ '( a, b, c, d)]
 a = undefined
 
 -- nested promoted tuples.

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1629,11 +1629,19 @@ typ x = case x of
             do pretty left
                write " ~ "
                pretty right
-          TyPromoted _ (PromotedList _ _ (first@(TyPromoted _ _) : rest)) ->
-            do wrap "'[" "]" $ do
-                 space
-                 pretty' first
-                 mapM_ pretty' rest
+          TyPromoted _ (PromotedList _ _ ts) ->
+            do write "'["
+               unless (null ts) $ write " "
+               commas (map pretty ts)
+               write "]"
+          TyPromoted _ (PromotedTuple _ ts) ->
+            do trace "ccc" $ write "'("
+               unless (null ts) $ write " "
+               commas (map pretty ts)
+               write ")"
+          TyPromoted _ (PromotedCon _ _ tname) ->
+            do write "'"
+               pretty tname
           ty@TyPromoted{} -> pretty' ty
           TySplice _ splice -> pretty splice
           TyWildCard _ name ->

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1617,7 +1617,7 @@ typ x = case x of
                commas (map pretty ts)
                write "]"
           TyPromoted _ (PromotedTuple _ ts) ->
-            do trace "ccc" $ write "'("
+            do write "'("
                unless (null ts) $ write " "
                commas (map pretty ts)
                write ")"

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -429,13 +429,6 @@ prettyInfixOp x =
         Symbol _ s -> string s
     Special _ s -> pretty s
 
-prettyInfixTypeOp :: Type NodeInfo -> Printer ()
-prettyInfixTypeOp t = case t of
-  TyPromoted _ (PromotedCon _ _ op) -> do
-    write "'"
-    prettyInfixOp op
-  _ -> pretty t
-
 instance Pretty Type where
   prettyInternal  =
     typ
@@ -1583,18 +1576,7 @@ typ x = case x of
             brackets (do write ":"
                          pretty t
                          write ":")
-          TyApp _ f a ->
-            case f of
-              TyApp _ g op@(TyPromoted _ (PromotedCon _ _ (UnQual _ (Symbol _ _)))) -> do
-                -- workaround for HSE parsing bug
-                pretty g
-                space
-                prettyInfixTypeOp op
-                ifFitsOnOneLineThenSpaceElseNewline $ pretty a
-              _ -> do
-                pretty f
-                space
-                pretty a
+          TyApp _ f a -> spaced [pretty f, pretty a]
           TyVar _ n -> pretty n
           TyCon _ p ->
             case p of
@@ -1838,11 +1820,6 @@ ifFitsOnOneLineOrElse a b = do
     Nothing -> do
       put stOrig
       b
-
--- | If printer after fits, use it, else use it after newline
-ifFitsOnOneLineThenSpaceElseNewline :: Printer a -> Printer a
-ifFitsOnOneLineThenSpaceElseNewline p =
-  ifFitsOnOneLineOrElse (space >> p) (newline >> p)
 
 bindingGroup :: Binds NodeInfo -> Printer ()
 bindingGroup binds =


### PR DESCRIPTION
+ Fix  promoted types pretty printing (including #348, promoted lists).
+ Clean up some unnecessary code introduced by #341 and #344. These two pull requests wanted to fix the pretty printing of `PromotedCon `, but in the improper way. The fundamental cause of the problem is the incorrect handling of promoted types.