### PR TITLE
Do not prefix quasiquoter name with '$'

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1126,3 +1126,7 @@ exp' (App _ op a) = do
     flatten (App _ f' a') b = flatten f' (a' : b)
     flatten f' as = (f', as)
 ```
+Quasi quotes
+```haskell
+exp = [name|exp|]
+```

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -400,8 +400,7 @@ instance Pretty Pat where
                    write " -> ")
                (pretty p)
       PQuasiQuote _ name str ->
-        brackets (depend (do write "$"
-                             string name
+        brackets (depend (do string name
                              write "|")
                          (string str))
       PBangPat _ p ->


### PR DESCRIPTION
This is no longer necessary since `7.0` according to paragraph `1.5.8` of the [release notes](https://downloads.haskell.org/~ghc/7.0.1/docs/html/users_guide/release-7-0-1.html). Even worse it causes a parse error in GHC 8 (that might be a bug as I couldn’t find it in the release notes) and I also don’t think it’s common to have a `$` here.