### PR TITLE
 Make fitsOnOneLine O(1). 

### DIFF
--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -178,7 +178,7 @@ runPrinterStyle config m =
               , psLine = 1
               , psConfig = config
               , psInsideCase = False
-              , psHardLimit = False
+              , psFitOnOneLine = False
               , psEolComment = False
               }))))
 

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -231,7 +231,7 @@ int = write . show
 write :: String -> Printer ()
 write x =
   do eol <- gets psEolComment
-     hardFail <- gets psHardLimit
+     hardFail <- gets psFitOnOneLine
      let addingNewline = eol && x /= "\n"
      when addingNewline newline
      state <- get
@@ -2030,23 +2030,23 @@ isLineBreak _ = return False
 fitsOnOneLine :: Printer a -> Printer (Maybe PrintState)
 fitsOnOneLine p =
   do st <- get
-     put st { psHardLimit = True}
+     put st { psFitOnOneLine = True}
      ok <- fmap (const True) p <|> return False
      st' <- get
      put st
      return (if ok
-                then Just st' { psHardLimit = psHardLimit st }
+                then Just st' { psFitOnOneLine = psFitOnOneLine st }
                 else Nothing)
 
 -- | If first printer fits, use it, else use the second one.
 ifFitsOnOneLineOrElse :: Printer a -> Printer a -> Printer a
 ifFitsOnOneLineOrElse a b = do
   stOrig <- get
-  put stOrig{psHardLimit = True}
+  put stOrig{psFitOnOneLine = True}
   res <- fmap Just a <|> return Nothing
   case res of
     Just r -> do
-      modify $ \st -> st{psHardLimit = psHardLimit stOrig}
+      modify $ \st -> st{psFitOnOneLine = psFitOnOneLine stOrig}
       return r
     Nothing -> do
       put stOrig

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2034,6 +2034,7 @@ fitsOnOneLine p =
      ok <- fmap (const True) p <|> return False
      st' <- get
      put st
+     guard $ ok || not (psFitOnOneLine st)
      return (if ok
                 then Just st' { psFitOnOneLine = psFitOnOneLine st }
                 else Nothing)
@@ -2050,6 +2051,7 @@ ifFitsOnOneLineOrElse a b = do
       return r
     Nothing -> do
       put stOrig
+      guard $ not (psFitOnOneLine stOrig)
       b
 
 bindingGroup :: Binds NodeInfo -> Printer ()

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -52,8 +52,9 @@ data PrintState = PrintState
     -- ^ Configuration of max colums and indentation style.
   , psInsideCase :: !Bool
     -- ^ Whether we're in a case statement, used for Rhs printing.
-  , psHardLimit :: !Bool
-    -- ^ Bail out if we exceed current column.
+  , psFitOnOneLine :: !Bool
+    -- ^ Bail out if we need to print beyond the current line or
+    -- the maximum column.
   , psEolComment :: !Bool
   }
 


### PR DESCRIPTION
Fixes #531.

`fitsOnOneLine` has to fail rather than allow to continue execution when the caller is also trying to fit in one line only. Otherwise, evaluation will continue in useless rendering attempts.